### PR TITLE
Add properties for image width/height

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -464,7 +464,8 @@ class ImageWidget(ipyw.VBox):
         xy_col = np.asarray(xy_col)  # [[x0, y0], [x1, y1], ...]
 
         if include_skycoord:
-            radec_col = np.asarray(radec_col)  # [[ra0, dec0], [ra1, dec1], ...]
+            # [[ra0, dec0], [ra1, dec1], ...]
+            radec_col = np.asarray(radec_col)
 
             # Fill in X,Y from RA,DEC
             mask = np.isnan(xy_col[:, 0])  # One bool per row

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -40,7 +40,7 @@ class ImageWidget(ipyw.VBox):
             logger = get_logger('my_viewer', log_stderr=False,
                                 log_file='ginga.log', level=40)
 
-    width, height : int
+    image_width, image_height : int
         Dimension of Jupyter notebook's image widget.
 
     use_opencv : bool
@@ -49,7 +49,9 @@ class ImageWidget(ipyw.VBox):
         do not have ``opencv``, you will get a warning.
 
     """
-    def __init__(self, logger=None, width=500, height=500, use_opencv=True):
+
+    def __init__(self, logger=None, image_width=500, image_height=500,
+                 use_opencv=True):
         super().__init__()
 
         # TODO: Is this the best place for this?
@@ -64,7 +66,15 @@ class ImageWidget(ipyw.VBox):
         self._is_marking = False
         self._click_center = False
 
-        self._jup_img = ipyw.Image(format='jpeg', width=width, height=height)
+        self._jup_img = ipyw.Image(format='jpeg')
+        self._jup_img.layout.width = str(image_width)
+        self._jup_img.layout.height = str(image_height)
+
+        # These need to also be set for now (until ginga
+        # is modified to use the layout width/height)
+        self._jup_img.width = self._jup_img.layout.width
+        self._jup_img.height = self._jup_img.layout.height
+
         self._viewer.set_widget(self._jup_img)
 
         # enable all possible keyboard and pointer operations
@@ -96,6 +106,14 @@ class ImageWidget(ipyw.VBox):
     def logger(self):
         """Logger for this widget."""
         return self._viewer.logger
+
+    @property
+    def image_width(self):
+        return int(self._jup_img.layout.width)
+
+    @property
+    def image_height(self):
+        return int(self._jup_img.layout.height)
 
     def _mouse_move_cb(self, viewer, button, data_x, data_y):
         """

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -50,7 +50,7 @@ class ImageWidget(ipyw.VBox):
 
     """
 
-    def __init__(self, logger=None, image_width=500, image_height=500,
+    def __init__(self, logger=None, width=500, height=500,
                  use_opencv=True):
         super().__init__()
 
@@ -67,13 +67,28 @@ class ImageWidget(ipyw.VBox):
         self._click_center = False
 
         self._jup_img = ipyw.Image(format='jpeg')
-        self._jup_img.layout.width = str(image_width)
-        self._jup_img.layout.height = str(image_height)
 
-        # These need to also be set for now (until ginga
-        # is modified to use the layout width/height)
-        self._jup_img.width = self._jup_img.layout.width
-        self._jup_img.height = self._jup_img.layout.height
+        # Set the image margin to over the widgets default of 2px on
+        # all sides.
+        self._jup_img.layout.margin = '0'
+
+        # Set both of those to ensure consistent display in notebook
+        # and jupyterlab when the image is put into a container smaller
+        # than the image.
+
+        self._jup_img.max_width = '100%'
+        self._jup_img.height = 'auto'
+
+        # Set the width of the box containing the image to the desired width
+        self.layout.width = str(width)
+
+        # Note we are NOT setting the height. That is because the height
+        # is automatically set by the image aspect ratio.
+
+        # These need to also be set for now; ginga uses them to figure
+        # out what size image to make.
+        self._jup_img.width = width
+        self._jup_img.height = height
 
         self._viewer.set_widget(self._jup_img)
 
@@ -109,11 +124,23 @@ class ImageWidget(ipyw.VBox):
 
     @property
     def image_width(self):
-        return int(self._jup_img.layout.width)
+        return int(self._jup_img.width)
+
+    @image_width.setter
+    def image_width(self, value):
+        # widgets expect width/height as strings, but most users will not, so
+        # do the conversion.
+        self._jup_img.width = str(value)
 
     @property
     def image_height(self):
-        return int(self._jup_img.layout.height)
+        return int(self._jup_img.height)
+
+    @image_height.setter
+    def image_height(self, value):
+        # widgets expect width/height as strings, but most users will not, so
+        # do the conversion.
+        self._jup_img.height = str(value)
 
     def _mouse_move_cb(self, viewer, button, data_x, data_y):
         """

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -50,7 +50,7 @@ class ImageWidget(ipyw.VBox):
 
     """
 
-    def __init__(self, logger=None, width=500, height=500,
+    def __init__(self, logger=None, image_width=500, image_height=500,
                  use_opencv=True):
         super().__init__()
 
@@ -80,15 +80,15 @@ class ImageWidget(ipyw.VBox):
         self._jup_img.height = 'auto'
 
         # Set the width of the box containing the image to the desired width
-        self.layout.width = str(width)
+        self.layout.width = str(image_width)
 
         # Note we are NOT setting the height. That is because the height
         # is automatically set by the image aspect ratio.
 
         # These need to also be set for now; ginga uses them to figure
         # out what size image to make.
-        self._jup_img.width = width
-        self._jup_img.height = height
+        self._jup_img.width = image_width
+        self._jup_img.height = image_height
 
         self._viewer.set_widget(self._jup_img)
 
@@ -131,6 +131,7 @@ class ImageWidget(ipyw.VBox):
         # widgets expect width/height as strings, but most users will not, so
         # do the conversion.
         self._jup_img.width = str(value)
+        self._viewer.set_window_size(self.image_width, self.image_height)
 
     @property
     def image_height(self):
@@ -141,6 +142,7 @@ class ImageWidget(ipyw.VBox):
         # widgets expect width/height as strings, but most users will not, so
         # do the conversion.
         self._jup_img.height = str(value)
+        self._viewer.set_window_size(self.image_width, self.image_height)
 
     def _mouse_move_cb(self, viewer, button, data_x, data_y):
         """

--- a/astrowidgets/tests/test_api.py
+++ b/astrowidgets/tests/test_api.py
@@ -167,3 +167,9 @@ def test_save():
     image = ImageWidget()
     filename = 'woot.png'
     image.save(filename)
+
+
+def test_width_height():
+    image = ImageWidget(image_width=250, image_height=100)
+    assert image.image_width == 250
+    assert image.image_height == 100

--- a/astrowidgets/tests/test_image_wdiget.py
+++ b/astrowidgets/tests/test_image_wdiget.py
@@ -1,0 +1,10 @@
+from ..core import ImageWidget
+
+
+def test_setting_image_width_height():
+    image = ImageWidget()
+    width = 200
+    height = 300
+    image.image_width = width
+    image.image_height = height
+    assert image._viewer.get_window_size() == (width, height)


### PR DESCRIPTION
This is an alternative to #14. 

There are really two sizes here:

+ The width/height of the image
+ The width/height of the ipywidgets Box containing the image and the cursor display. 

I guessing most users will care more about the *image* size; to make explicit that that is what is settable I've changed the names to `image_width` and `image_height`. 

Ideally those would be set to the width/height of the *layout* of the image widget rather than the image itself. The reason is that any css that applies to the image will override the img width/height tags. That means, for example, that setting the width of the `ipywidgets.Vbox` using the `layout` of the `VBox`, which applies the css width to everything in the box, will override the img width/height.

If we set width/height of the layout then it is applied via css. In addition, setting the width/height this way allows more flexible values (e.g. as a percent). 

edit: reference for image width/height on the img attribute vs via CSS: https://www.w3schools.com/html/html_images.asp