### PR TITLE
Add link to astropy code of conduct

### DIFF
--- a/CODA_OF_CONDUCT.md
+++ b/CODA_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please read the [Astropy Project Code of Conduct](http://www.astropy.org/code_of_conduct.html).


### PR DESCRIPTION
This uses astropy's way of adding the CoC, with a link to the actual CoC in a document.

I'm happy with that or with:

+ adding  a link to the CoC to the README, and
+ adding the text of the CoC to `CODE_OF_CONDUCT`

Either way, fixes #2.