### PR TITLE
Speed up adding markers in world coordinates by 100x

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -538,10 +538,11 @@ class ImageWidget(ipyw.VBox):
                 raise ValueError(
                     'Image has no valid WCS, '
                     'try again with use_skycoord=False')
-            coord_type = 'wcs'
             coord_val = table[skycoord_colname]
-            coord_x = coord_val.ra.deg
-            coord_y = coord_val.dec.deg
+            coord_x, coord_y = image.wcs.wcs.all_world2pix(coord_val.ra.deg,
+                                                           coord_val.dec.deg,
+                                                           0)
+            coord_type = 'data'
         else:  # Use X,Y
             coord_type = 'data'
             coord_x = table[x_colname].data

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -528,6 +528,11 @@ class ImageWidget(ipyw.VBox):
 
         """
         # TODO: Resolve https://github.com/ejeschke/ginga/issues/672
+
+        # For now we always convert marker locations to pixels; see
+        # comment below.
+        coord_type = 'data'
+
         # Extract coordinates from table.
         # They are always arrays, not scalar.
         if use_skycoord:
@@ -539,12 +544,14 @@ class ImageWidget(ipyw.VBox):
                     'Image has no valid WCS, '
                     'try again with use_skycoord=False')
             coord_val = table[skycoord_colname]
+            # TODO: Maybe switch back to letting ginga handle conversion
+            #       to pixel coordinates.
+            # Convert to pixels here (instead of in ginga) because conversion
+            # in ginga is currently very slow.
             coord_x, coord_y = image.wcs.wcs.all_world2pix(coord_val.ra.deg,
                                                            coord_val.dec.deg,
                                                            0)
-            coord_type = 'data'
         else:  # Use X,Y
-            coord_type = 'data'
             coord_x = table[x_colname].data
             coord_y = table[y_colname].data
             # Convert data coordinates from 1-indexed to 0-indexed

--- a/astrowidgets/tests/test_image_wdiget.py
+++ b/astrowidgets/tests/test_image_wdiget.py
@@ -1,5 +1,9 @@
 import numpy as np
 from astropy.table import Table
+from astropy.wcs import WCS
+from astropy.nddata import CCDData
+from astropy.coordinates import SkyCoord
+
 from ..core import ImageWidget
 
 
@@ -25,3 +29,32 @@ def test_add_marker_does_not_modify_input_table():
     in_table = Table(data=[x, y], names=['x', 'y'])
     image.add_markers(in_table, pixel_coords_offset=5)
     assert (in_table == orig_table).all()
+
+
+def test_adding_markers_as_world_recovers_with_get_markers():
+    """
+    Make sure that our internal conversion from world to pixel
+    coordinates doesn't mess anything up.
+    """
+    fake_image = np.random.randn(2000, 2000)
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = (fake_image.shape[0] / 2, fake_image.shape[1] / 2)
+    wcs.wcs.ctype = ('RA---TAN', 'DEC--TAN')
+    wcs.wcs.crval = (314.275419158, 31.6662781301)
+    wcs.wcs.pc = [[0.000153051015113,  -3.20700931602e-05], [3.20704370872e-05, 0.000153072382405]]
+    fake_ccd = CCDData(data=fake_image, wcs=wcs, unit='adu')
+    iw = ImageWidget()
+    iw.load_nddata(fake_ccd)
+    # Get me 1000 positions please
+    marker_locs = np.random.randint(10, high=1990, size=(1000, 2))
+    marks_pix = Table(data=marker_locs, names=['x', 'y'])
+    marks_world = wcs.all_pix2world(marker_locs, 0)
+    marks_coords = SkyCoord(marks_world, unit='degree')
+    mark_coord_table = Table(data=[marks_coords], names=['coord'])
+    iw.add_markers(mark_coord_table, use_skycoord=True)
+    result = iw.get_markers(pixel_coords_offset=0)
+    # Check the x, y positions as long as we are testing things...
+    np.testing.assert_allclose(result['x'], marks_pix['x'])
+    np.testing.assert_allclose(result['y'], marks_pix['y'])
+    np.testing.assert_allclose(result['coord'].ra.deg, mark_coord_table['coord'].ra.deg)
+    np.testing.assert_allclose(result['coord'].dec.deg, mark_coord_table['coord'].dec.deg)

--- a/astrowidgets/tests/test_image_wdiget.py
+++ b/astrowidgets/tests/test_image_wdiget.py
@@ -41,7 +41,8 @@ def test_adding_markers_as_world_recovers_with_get_markers():
     wcs.wcs.crpix = (fake_image.shape[0] / 2, fake_image.shape[1] / 2)
     wcs.wcs.ctype = ('RA---TAN', 'DEC--TAN')
     wcs.wcs.crval = (314.275419158, 31.6662781301)
-    wcs.wcs.pc = [[0.000153051015113,  -3.20700931602e-05], [3.20704370872e-05, 0.000153072382405]]
+    wcs.wcs.pc = [[0.000153051015113, -3.20700931602e-05],
+                  [3.20704370872e-05, 0.000153072382405]]
     fake_ccd = CCDData(data=fake_image, wcs=wcs, unit='adu')
     iw = ImageWidget()
     iw.load_nddata(fake_ccd)
@@ -56,5 +57,7 @@ def test_adding_markers_as_world_recovers_with_get_markers():
     # Check the x, y positions as long as we are testing things...
     np.testing.assert_allclose(result['x'], marks_pix['x'])
     np.testing.assert_allclose(result['y'], marks_pix['y'])
-    np.testing.assert_allclose(result['coord'].ra.deg, mark_coord_table['coord'].ra.deg)
-    np.testing.assert_allclose(result['coord'].dec.deg, mark_coord_table['coord'].dec.deg)
+    np.testing.assert_allclose(result['coord'].ra.deg,
+                               mark_coord_table['coord'].ra.deg)
+    np.testing.assert_allclose(result['coord'].dec.deg,
+                               mark_coord_table['coord'].dec.deg)

--- a/astrowidgets/tests/test_image_wdiget.py
+++ b/astrowidgets/tests/test_image_wdiget.py
@@ -36,7 +36,8 @@ def test_adding_markers_as_world_recovers_with_get_markers():
     Make sure that our internal conversion from world to pixel
     coordinates doesn't mess anything up.
     """
-    fake_image = np.random.randn(2000, 2000)
+    npix_side = 100
+    fake_image = np.random.randn(npix_side, npix_side)
     wcs = WCS(naxis=2)
     wcs.wcs.crpix = (fake_image.shape[0] / 2, fake_image.shape[1] / 2)
     wcs.wcs.ctype = ('RA---TAN', 'DEC--TAN')
@@ -46,8 +47,10 @@ def test_adding_markers_as_world_recovers_with_get_markers():
     fake_ccd = CCDData(data=fake_image, wcs=wcs, unit='adu')
     iw = ImageWidget()
     iw.load_nddata(fake_ccd)
-    # Get me 1000 positions please
-    marker_locs = np.random.randint(10, high=1990, size=(1000, 2))
+    # Get me 100 positions please, not right at the edge
+    marker_locs = np.random.randint(10,
+                                    high=npix_side - 10,
+                                    size=(100, 2))
     marks_pix = Table(data=marker_locs, names=['x', 'y'])
     marks_world = wcs.all_pix2world(marker_locs, 0)
     marks_coords = SkyCoord(marks_world, unit='degree')


### PR DESCRIPTION
This fixes #50 by internally converting SkyCoord markers to pixel coordinates. I'm not sure what makes adding markers with `coord_type='wcs'` so slow, but it is. Simply adding 1000 markers as WCS took 12 seconds before this PR, compared to 0.2 seconds for adding 1000 markers in pixel coordinates. 

Line profiles are below demonstrating where the slowdown was occurring. 

I also added a test that the internal conversion to pixels still gives the correct worl coordinates back via `get_markers`.