### PR TITLE
Remove a couple of to-dos from the example notebook

### DIFF
--- a/example_notebooks/ginga_widget.ipynb
+++ b/example_notebooks/ginga_widget.ipynb
@@ -157,8 +157,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If this does not work, see\n",
-    "# https://github.com/astropy/astrowidgets/issues/36\n",
     "w.cursor = 'top'  # 'top', 'bottom', None\n",
     "print(w.cursor)"
    ]
@@ -440,11 +438,10 @@
    "outputs": [],
    "source": [
     "# Erase them again\n",
-    "#w.reset_markers()\n",
+    "w.reset_markers()\n",
     "\n",
-    "# TODO: Make this work (https://github.com/astropy/astrowidgets/issues/37)\n",
     "# Programmatically re-mark from table using SkyCoord\n",
-    "#w.add_markers(markers_table, use_skycoord=True)"
+    "w.add_markers(markers_table, use_skycoord=True)"
    ]
   },
   {
@@ -539,22 +536,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We redisplay the image widget below above the slider. Note that the slider affects both this view of the image widget and the one near the top of the notebook."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: display the slider right below the viewer.\n",
-    "# https://github.com/astropy/astrowidgets/issues/38\n",
-    "#from IPython.display import display\n",
+    "from IPython.display import display\n",
     "\n",
     "import ipywidgets as ipyw\n",
-    "from ipywidgets import interact\n",
+    "from ipywidgets import interactive\n",
     "\n",
     "# Show the slider widget.\n",
-    "interact(\n",
-    "    show_circles,\n",
-    "    n=ipyw.IntSlider(min=0,max=len(t),step=1,value=0));"
+    "slider = interactive(show_circles,\n",
+    "                     n=ipyw.IntSlider(min=0,max=len(t),step=1,value=0, continuous_update=False))\n",
+    "display(w, slider)"
    ]
   },
   {
@@ -581,7 +583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Turns out a couple of the open issues/notebook to-dos have already been fixed 😀. This just removes a couple of notes from the notebook and finishes up the slider-to-control-number-of-stars demo.

Fixes #37 
Fixes #38  