### PR TITLE
Fix jupyter lab compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ edit_on_github = True
 github_project = astropy/astrowidgets
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy, ginga, pillow, ipywidgets, ipyevents
+install_requires = astropy, ginga, pillow, ipywidgets, ipyevents>=0.4.0
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.0.dev0
 # Note: you will also need to change this in your package's __init__.py


### PR DESCRIPTION
The real work has been done in ipyevents; this simply sets a new lower bound for the version of that package.

One side effect of the changes is that the image widget now has a blue border around it when it has focus. I don't think that is a problem, but if we want to address we can by adding the appropriate styling (though I'd rather do that in a separate PR).

This fixes #44 and I think also mwcraig/ipyevents#27