### PR TITLE
Expose methods for colormap

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -739,6 +739,25 @@ class ImageWidget(ipyw.VBox):
             self._viewer.cut_levels(val[0], val[1])
 
     @property
+    def colormap_options(self):
+        """List of colormap names."""
+        from ginga import cmap
+        return cmap.get_names()
+
+    def set_colormap(self, cmap):
+        """
+        Set colormap to the given colormap name.
+
+        Parameters
+        ----------
+        cmap : str
+            Colormap name. Possible values can be obtained from
+            :meth:`colormap_options`.
+
+        """
+        self._viewer.set_color_map(cmap)
+
+    @property
     def cursor(self):
         """
         Show or hide cursor information (X, Y, WCS).

--- a/astrowidgets/tests/test_api.py
+++ b/astrowidgets/tests/test_api.py
@@ -146,6 +146,15 @@ def test_cuts():
     assert image.cuts == (10, 100)
 
 
+def test_colormap():
+    image = ImageWidget()
+    cmap_desired = 'gray'
+    cmap_list = image.colormap_options
+    assert len(cmap_list) > 0 and cmap_desired in cmap_list
+
+    image.set_colormap(cmap_desired)
+
+
 def test_cursor():
     image = ImageWidget()
     assert image.cursor in ALLOWED_CURSOR_LOCATIONS


### PR DESCRIPTION
I implemented this for spacetelescope/dat_pyinthesky#7 because it was painful to cycle through colormaps interactively using arrow keys. With this, I can programmatically set the colormap I want.