### PR TITLE
Add a generic load_file method

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -251,8 +251,11 @@ class ImageWidget(ipyw.VBox):
             Extra keywords to be passed into the viewer's file handler.
 
         """
-        image = AstroImage(logger=self.logger)
-        image.load_file(filename, **kwargs)
+        from ginga.util import loader
+
+        image = loader.load_data(filename, logger=self.logger, **kwargs)
+        if not isinstance(image, AstroImage):
+            raise ValueError("Default index in '{}' does not reference an image".format(filename))
         self._viewer.set_image(image)
 
     def load_fits(self, fitsorfn, numhdu=None, memmap=None):

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -237,6 +237,24 @@ class ImageWidget(ipyw.VBox):
 #         from IPython.display import display
 #         return display(self._widget)
 
+    def load_file(self, filename, **kwargs):
+        """
+        Load a given file into the viewer. This relies on the viewer
+        to identify the best file handler to use.
+
+        Parameters
+        ----------
+        filename : str
+            File name.
+
+        kwargs : dict
+            Extra keywords to be passed into the viewer's file handler.
+
+        """
+        image = AstroImage(logger=self.logger)
+        image.load_file(filename, **kwargs)
+        self._viewer.set_image(image)
+
     def load_fits(self, fitsorfn, numhdu=None, memmap=None):
         """
         Load a FITS file into the viewer.

--- a/astrowidgets/tests/test_api.py
+++ b/astrowidgets/tests/test_api.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 
 import pytest
@@ -13,11 +11,16 @@ from ginga.ColorDist import ColorDistBase
 from ..core import ImageWidget, ALLOWED_CURSOR_LOCATIONS
 
 
-def test_load_fits():
+def test_load_fits(tmpdir):
     image = ImageWidget()
     data = np.random.random([100, 100])
     hdu = fits.PrimaryHDU(data=data)
     image.load_fits(hdu)
+
+    # Load it as a file
+    filename = str(tmpdir.join('randomimage.fits'))
+    hdu.writeto(filename, overwrite=True)
+    image.load_file(filename)
 
 
 def test_load_nddata():


### PR DESCRIPTION
This would fix #64 indirectly, as theoretically I could implement whatever Ginga file handler I want outside of the widget, register it with Ginga, and then simply use this to open my custom file format.

https://github.com/ejeschke/ginga/blob/bbfe6455d302266c1bfd3f01bd386fbc2494f3db/ginga/AstroImage.py#L186

I can add a test if you think this is an acceptable way forward. I am open to discussions. Thanks!

Depends on: ejeschke/ginga#764

cc @ejeschke