### PR TITLE
Simplify saving image view as PNG

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -835,9 +835,11 @@ class ImageWidget(ipyw.VBox):
         """
         raise NotImplementedError
 
-    # https://github.com/ejeschke/ginga/pull/665
     def save(self, filename):
         """
         Save out the current image view to given PNG filename.
         """
-        self._viewer.save_rgb_image_as_file(filename)
+        # It turns out the image value is already in PNG format so we just
+        # to write that out to a file.
+        with open(filename, 'wb') as f:
+            f.write(self._jup_img.value)


### PR DESCRIPTION
As it happens the `value` if the `Image` widget is bytes in PNG format so we just need to write it out. This also makes the save independent of ginga.