### PR TITLE
A couple little fixes for marker names

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -597,6 +597,8 @@ class ImageWidget(ipyw.VBox):
         else:
             markers_table = Table(xy_col, names=(x_colname, y_colname))
 
+        # Either way, add the marker names
+        markers_table['marker name'] = marker_name
         return markers_table
 
     def add_markers(self, table, x_colname='x', y_colname='y',

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -135,7 +135,8 @@ class ImageWidget(ipyw.VBox):
         self._marktags = set()
         # Let's have a default name for the tag too:
         self._default_mark_tag_name = 'default-marker-name'
-        self._interactive_marker_set_name = 'interactive-markers'
+        self._interactive_marker_set_name_default = 'interactive-markers'
+        self._interactive_marker_set_name = self._interactive_marker_set_name_default
 
         # coordinates display
         self._jup_coord = ipyw.HTML('Coordinates show up here')
@@ -417,6 +418,13 @@ class ImageWidget(ipyw.VBox):
         # Set scroll_pan to ensure there is a mouse way to pan
         self.scroll_pan = True
         self._is_marking = True
+        if marker_name is not None:
+            self._validate_marker_name(marker_name)
+            self._interactive_marker_set_name = marker_name
+            self._marktags.add(marker_name)
+        else:
+            self._interactive_marker_set_name = \
+                self._interactive_marker_set_name_default
         if marker is not None:
             self.marker = marker
 
@@ -601,6 +609,16 @@ class ImageWidget(ipyw.VBox):
         markers_table['marker name'] = marker_name
         return markers_table
 
+    def _validate_marker_name(self, marker_name):
+        """
+        Raise an error if the marker_name is not allowed.
+        """
+        if marker_name in RESERVED_MARKER_SET_NAMES:
+            raise ValueError('The marker name {} is not allowed. Any name is '
+                             'allowed except these: '
+                             '{}'.format(marker_name,
+                                         ', '.join(RESERVED_MARKER_SET_NAMES)))
+
     def add_markers(self, table, x_colname='x', y_colname='y',
                     skycoord_colname='coord', use_skycoord=False,
                     marker_name=None):
@@ -642,11 +660,7 @@ class ImageWidget(ipyw.VBox):
         if marker_name is None:
             marker_name = self._default_mark_tag_name
 
-        if marker_name in RESERVED_MARKER_SET_NAMES:
-            raise ValueError('The marker name {} is not allowed. Any name is '
-                             'allowed except these: '
-                             '{}'.format(marker_name,
-                                         ', '.join(RESERVED_MARKER_SET_NAMES)))
+        self._validate_marker_name(marker_name)
 
         self._marktags.add(marker_name)
 

--- a/example_notebooks/named_markers.ipynb
+++ b/example_notebooks/named_markers.ipynb
@@ -138,7 +138,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Start clicking interactively, red circls radius 30 px"
+    "### Start clicking interactively, red circles radius 30 px\n",
+    "\n",
+    "The `marker_name` argument is optional. If no name is given then the name defaults to `self._interactive_marker_set_name_default`, whose value is `interactive-markers`."
    ]
   },
   {
@@ -147,8 +149,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#imw.marker = {'color': 'red', 'radius': 30, 'type': 'circle'}\n",
-    "imw.start_marking(marker={'color': 'red', 'radius': 30, 'type': 'circle'})"
+    "imw.start_marking(marker={'color': 'red', 'radius': 30, 'type': 'circle'},\n",
+    "                  marker_name='clicked markers'\n",
+    "                 )"
    ]
   },
   {
@@ -180,9 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get a list of the interactive markers\n",
-    "\n",
-    "The name of the interactive marker layer is in `self._interactive_marker_set_name`"
+    "### Get a list of the interactive markers"
    ]
   },
   {
@@ -191,7 +192,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imw.get_markers(marker_name='interactive-markers')"
+    "imw.get_markers(marker_name='clicked markers')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add more interactive markers using default marker name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imw.start_marking(marker={'color': 'red', 'radius': 10, 'type': 'cross'}                 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imw.stop_marking()"
    ]
   },
   {
@@ -241,13 +267,6 @@
    "source": [
     "imw.reset_markers()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This does two things:

+ Report the names of the markers in the table returned by `get_markers`
+ Use the name passed in to `start_marking`