### PR TITLE
ENH: Update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - GINGA_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
@@ -38,7 +39,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='ginga ipyevents pillow'
+        - CONDA_DEPENDENCIES='ipyevents pillow'
 
         # List other runtime dependencies for the package that are available as
         # pip packages here.
@@ -87,6 +88,7 @@ matrix:
         # Now try Astropy dev with the latest Python and LTS with Python 3.x.
         - stage: Comprehensive tests
           env: ASTROPY_VERSION=development
+               GINGA_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - stage: Comprehensive tests
           env: ASTROPY_VERSION=lts
@@ -100,11 +102,6 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13
         - stage: Comprehensive tests
           env: NUMPY_VERSION=1.14
-
-        # Try numpy pre-release
-        - stage: Comprehensive tests
-          env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='pull_request push cron'
 
         # Do a PEP8 test with flake8
         - stage: Comprehensive tests
@@ -139,6 +136,10 @@ install:
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any
     # other dependencies.
+
+    # GINGS
+    - if [[ $GINGA_VERSION == development ]]; then pip -q install git+https://github.com/ejeschke/ginga.git#egg=ginga; fi
+    - if [[ $GINGA_VERSION == stable ]]; then pip -q install ginga; fi
 
 script:
    - $MAIN_CMD $SETUP_CMD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ environment:
 
       # List other runtime dependencies for the package that are available as
       # conda packages here.
-      CONDA_DEPENDENCIES: "ginga ipyevents pillow"
-
+      CONDA_DEPENDENCIES: "ipyevents pillow"
+      PIP_DEPENDENCIES: "ginga"
 
       # Conda packages for affiliated packages are hosted in channel
       # "astropy" while builds for astropy LTS with recent numpy versions
@@ -26,9 +26,9 @@ environment:
 
   matrix:
 
-      # We test 3.6
+      # We test 3.7
 
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 

--- a/astrowidgets/conftest.py
+++ b/astrowidgets/conftest.py
@@ -31,12 +31,13 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 ## the list of packages for which version numbers are displayed when running
 ## the tests. Making it pass for KeyError is essential in some cases when
 ## the package uses other astropy affiliated packages.
-# try:
-#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-#     pass
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['Ginga'] = 'ginga'
+    del PYTEST_HEADER_MODULES['h5py']
+    del PYTEST_HEADER_MODULES['Pandas']
+except KeyError:
+    pass
 
 ## Uncomment the following lines to display the version number of the
 ## package rather than the version number of Astropy in the top line when

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ rst_epilog += """
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = setup_cfg['package_name']
+project = setup_cfg['name']
 author = setup_cfg['author']
 copyright = '{0}, {1}'.format(
     datetime.datetime.now().year, setup_cfg['author'])
@@ -78,8 +78,8 @@ copyright = '{0}, {1}'.format(
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-__import__(setup_cfg['package_name'])
-package = sys.modules[setup_cfg['package_name']]
+__import__(setup_cfg['name'])
+package = sys.modules[setup_cfg['name']]
 
 # The short X.Y version.
 version = package.__version__.split('-', 1)[0]
@@ -159,7 +159,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 if eval(setup_cfg.get('edit_on_github')):
     extensions += ['sphinx_astropy.ext.edit_on_github']
 
-    versionmod = __import__(setup_cfg['package_name'] + '.version')
+    versionmod = __import__(setup_cfg['name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']
     if versionmod.version.release:
         edit_on_github_branch = "v" + versionmod.version.version

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ ignore = E501
 exclude = setup_package.py,conftest.py,__init__.py
 
 [metadata]
-package_name = astrowidgets
+name = astrowidgets
 description = Widgets for the Jupyter notebook and JupyterLab
 long_description =
 author = Astropy Developers
@@ -39,7 +39,7 @@ github_project = astropy/astrowidgets
 # install_requires = astropy, scipy, matplotlib
 install_requires = astropy, ginga, pillow, ipywidgets, ipyevents>=0.4.0
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.1.0.dev0
+version = 0.1.0.dev
 # Note: you will also need to change this in your package's __init__.py
 minimum_python_version = 3.5
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
-PACKAGENAME = metadata.get('package_name', 'astrowidgets')
+PACKAGENAME = metadata.get('name', 'astrowidgets')
 DESCRIPTION = metadata.get('description', 'Widgets for the Jupyter notebook and JupyterLab')
 AUTHOR = metadata.get('author', 'Astropy Developers')
 AUTHOR_EMAIL = metadata.get('author_email', '')
@@ -34,11 +34,9 @@ from setuptools import setup
 import builtins
 builtins._ASTROPY_SETUP_ = True
 
-from astropy_helpers.setup_helpers import (register_commands, get_debug_option,
-                                           get_package_info)
+from astropy_helpers.setup_helpers import register_commands, get_package_info
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
-
 
 # order of priority for long_description:
 #   (1) set in setup.cfg,
@@ -80,11 +78,10 @@ if not RELEASE:
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
-cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
+cmdclassd = register_commands()
 
 # Freeze build information in version.py
-generate_version_py(PACKAGENAME, VERSION, RELEASE,
-                    get_debug_option(PACKAGENAME))
+version = generate_version_py()
 
 # Treat everything in scripts except README* as a script to be installed
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))


### PR DESCRIPTION
* Fix #83 by adding Ginga dev to Astropy dev job.
* Follow the lead of astropy/astropy#8891 and remove Numpy pre-release job. Any breakage caused by unreleased Numpy will be likely caught upstream first anyway. 🤞 
* Remove warnings from setup process.
* Update Appveyor to pip install Ginga (could not find in `conda`) and use Python 3.7.
* Improve pytest header to report dependency versions that we care about.