### PR TITLE
[EXP] WCS locking in multiple widgets

### DIFF
--- a/example_notebooks/linked_wcs_12_windows.ipynb
+++ b/example_notebooks/linked_wcs_12_windows.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use case: 12 linked windows with one candidate loaded for each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from ipywidgets import Label, Button, HBox, VBox, Layout\n",
+    "\n",
+    "from ginga.misc import Datasrc\n",
+    "from ginga.misc.log import get_logger\n",
+    "from ginga.util import wcsmod\n",
+    "from ginga.util.iohelper import get_fileinfo\n",
+    "\n",
+    "from astrowidgets import ImageWidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading ASDF in Ginga needs this to be specified early on\n",
+    "wcsmod.use('astropy_ape14')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = get_logger('my viewer', log_stderr=True, log_file=None, level=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LinkedImageWidget(ImageWidget):\n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        num_images = 10  # Max images in cache; should user be able to set this?\n",
+    "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
+    "        self._other_viewers = []\n",
+    "\n",
+    "    def load_jwst_asdf(self, filename):\n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "        else:\n",
+    "            import asdf\n",
+    "            from ginga.AstroImage import AstroImage\n",
+    "\n",
+    "            image = AstroImage(logger=self.logger)\n",
+    "            image.load_file(filename, data_key='data')\n",
+    "\n",
+    "            self.datasrc[filename] = image\n",
+    "\n",
+    "        self._viewer.set_image(image)\n",
+    "\n",
+    "    def load_fits(self, filename):\n",
+    "        bnch = get_fileinfo(filename)\n",
+    "        \n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "            self._viewer.set_image(image)\n",
+    "        else:\n",
+    "            super().load_fits(bnch.filepath, numhdu=bnch.numhdu)\n",
+    "            self.datasrc[filename] = self._viewer.get_image()\n",
+    "        \n",
+    "    def link_viewer(self, other_viewer):\n",
+    "        if other_viewer in self._other_viewers:\n",
+    "            raise ValueError('Viewer already linked')\n",
+    "        self._other_viewers.append(other_viewer)\n",
+    "\n",
+    "    @property\n",
+    "    def n_linked_viewers(self):\n",
+    "        return len(self._other_viewers)\n",
+    "\n",
+    "    def _mouse_click_cb(self, viewer, event, data_x, data_y):\n",
+    "        image = viewer.get_image()\n",
+    "        if image is None:  # Nothing to do\n",
+    "            return\n",
+    "        \n",
+    "        super()._mouse_click_cb(self._viewer, event, data_x, data_y)\n",
+    "\n",
+    "        for ov in self._other_viewers:\n",
+    "            if not isinstance(ov, ImageWidget):\n",
+    "                continue\n",
+    "    \n",
+    "            other_image = ov._viewer.get_image()\n",
+    "            if other_image is None:\n",
+    "                continue\n",
+    "                \n",
+    "            if image.wcs.wcs is not None and other_image.wcs.wcs is not None:\n",
+    "                ra, dec = image.pixtoradec(data_x, data_y)\n",
+    "                other_x, other_y = other_image.radectopix(ra, dec)\n",
+    "            else:\n",
+    "                other_x, other_y = data_x, data_y\n",
+    "\n",
+    "            ov._mouse_click_cb(ov._viewer, event, other_x, other_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_widgets = 12\n",
+    "w = []\n",
+    "w_labels = []\n",
+    "\n",
+    "for _ in range(n_widgets):\n",
+    "    i_w = LinkedImageWidget(logger=logger)\n",
+    "    i_w.click_center = True\n",
+    "    w.append(i_w)\n",
+    "    w_labels.append(Label('Filename'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First widget is primary viewer for WCS matching\n",
+    "for i in range(1, n_widgets):\n",
+    "    w[0].link_viewer(w[i])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fits_files = [\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
+    "n_files = len(fits_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign data to widgets.\n",
+    "# If there is not enough data, repeat the data for testing purposes.\n",
+    "for i in range(n_widgets):\n",
+    "    filename = fits_files[i % n_files]\n",
+    "    # w[i].load_fits(filename)  # FITS\n",
+    "    w[i].load_jwst_asdf(filename)  # JWST ASDF-in-FITS\n",
+    "    w_labels[i].value = os.path.basename(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "button_zoomlevel = Button(description=\"Sync zoom level\")\n",
+    "\n",
+    "def on_button_zoomlevel_clicked(b):\n",
+    "    for i in range(1, n_widgets):\n",
+    "        w[i].zoom_level = w[0].zoom_level\n",
+    "\n",
+    "button_zoomlevel.on_click(on_button_zoomlevel_clicked)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Manual arrangement for now\n",
+    "VBox([button_zoomlevel,\n",
+    "      HBox([VBox([w_labels[0], w[0]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[1], w[1]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[2], w[2]])]),\n",
+    "      HBox([VBox([w_labels[3], w[3]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[4], w[4]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[5], w[5]])]),\n",
+    "      HBox([VBox([w_labels[6], w[6]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[7], w[7]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[8], w[8]])]),\n",
+    "      HBox([VBox([w_labels[9], w[9]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[10], w[10]], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([w_labels[11], w[11]])])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Instructions\n",
+    "\n",
+    "Images are pre-loaded into viewers already.\n",
+    "\n",
+    "Click on the top left viewer and the rest will match in RA and Dec of centered point. No distortion correction is performed at this point.\n",
+    "\n",
+    "Press `+`/`-` to zoom in/out. Click \"Sync zoom level\" button to have the viewers match the zoom level of the top left one."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example_notebooks/linked_wcs_12_windows.ipynb
+++ b/example_notebooks/linked_wcs_12_windows.ipynb
@@ -57,6 +57,7 @@
     "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
     "        self._other_viewers = []\n",
     "\n",
+    "    # Need jwst package.\n",
     "    def load_jwst_asdf(self, filename):\n",
     "        if filename in self.datasrc:\n",
     "            image = self.datasrc[filename]\n",
@@ -149,9 +150,9 @@
    "outputs": [],
    "source": [
     "fits_files = [\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
     "n_files = len(fits_files)"
    ]
   },
@@ -239,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/example_notebooks/linked_wcs_2_windows.ipynb
+++ b/example_notebooks/linked_wcs_2_windows.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use case: 2 linked windows with \"a hundred\" candidates to load for each using drop-down menus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from ipywidgets import Dropdown, Label, Button, HBox, VBox, Layout\n",
+    "\n",
+    "from ginga.misc import Datasrc\n",
+    "from ginga.misc.log import get_logger\n",
+    "from ginga.util import wcsmod\n",
+    "from ginga.util.iohelper import get_fileinfo\n",
+    "\n",
+    "from astrowidgets import ImageWidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading ASDF in Ginga needs this to be specified early on\n",
+    "wcsmod.use('astropy_ape14')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = get_logger('my viewer', log_stderr=True, log_file=None, level=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "statusmsg = Label('')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LinkedImageWidget(ImageWidget):\n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        num_images = 10  # Max images in cache; should user be able to set this?\n",
+    "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
+    "        self._other_viewer = None\n",
+    "        \n",
+    "    def load_jwst_asdf(self, filename):\n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "        else:\n",
+    "            import asdf\n",
+    "            from ginga.AstroImage import AstroImage\n",
+    "\n",
+    "            image = AstroImage(logger=self.logger)\n",
+    "            image.load_file(filename, data_key='data')\n",
+    "\n",
+    "            self.datasrc[filename] = image\n",
+    "\n",
+    "        self._viewer.set_image(image)\n",
+    "\n",
+    "    def load_fits(self, filename):\n",
+    "        bnch = get_fileinfo(filename)\n",
+    "        \n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "            self._viewer.set_image(image)\n",
+    "        else:\n",
+    "            super().load_fits(bnch.filepath, numhdu=bnch.numhdu)\n",
+    "            self.datasrc[filename] = self._viewer.get_image()\n",
+    "        \n",
+    "    def link_viewer(self, other_viewer):\n",
+    "        self._other_viewer = other_viewer\n",
+    "\n",
+    "    def _mouse_click_cb(self, viewer, event, data_x, data_y):\n",
+    "        image = viewer.get_image()\n",
+    "        if image is None:  # Nothing to do\n",
+    "            return\n",
+    "              \n",
+    "        if isinstance(self._other_viewer, ImageWidget):\n",
+    "            other_image = self._other_viewer._viewer.get_image()\n",
+    "            if other_image is not None:\n",
+    "                if image.wcs.wcs is not None and other_image.wcs.wcs is not None:\n",
+    "                    ra, dec = image.pixtoradec(data_x, data_y)\n",
+    "                    other_x, other_y = other_image.radectopix(ra, dec)\n",
+    "                    statusmsg.value = f'Clicked RA={ra},Dec={dec}'\n",
+    "                else:\n",
+    "                    other_x, other_y = data_x, data_y\n",
+    "                    statusmsg.value = f'Clicked X={data_x},Y={data_y}'\n",
+    "            \n",
+    "                self._other_viewer._mouse_click_cb(self._other_viewer._viewer, event, other_x, other_y)\n",
+    "            \n",
+    "        super()._mouse_click_cb(self._viewer, event, data_x, data_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w1 = LinkedImageWidget(logger=logger)\n",
+    "w2 = LinkedImageWidget(logger=logger)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w1.link_viewer(w2)  # w1 is primary viewer for WCS matching\n",
+    "w1.click_center = True\n",
+    "w2.click_center = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fits_files = [\n",
+    "    'N/A',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def menu_factory(label, w):\n",
+    "    def menu(event):\n",
+    "        filename = event['new']\n",
+    "        if filename != 'N/A':\n",
+    "            label.value = os.path.basename(filename)\n",
+    "            # w.load_fits(filename)  # FITS\n",
+    "            w.load_jwst_asdf(filename)  # JWST ASDF-in-FITS\n",
+    "    return menu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label1 = Label('Filename')\n",
+    "label2 = Label('Filename')\n",
+    "statusmsg.value = ''  # Reset status message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown1 = Dropdown(\n",
+    "    options=fits_files,\n",
+    "    value='N/A',\n",
+    "    description='Select file:')\n",
+    "\n",
+    "dropdown2 = Dropdown(\n",
+    "    options=fits_files,\n",
+    "    value='N/A',\n",
+    "    description='Select file:')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown1.observe(menu_factory(label1, w1), 'value')\n",
+    "dropdown2.observe(menu_factory(label2, w2), 'value')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "button_zoomlevel = Button(description=\"Sync zoom level\")\n",
+    "\n",
+    "def on_button_zoomlevel_clicked(b):\n",
+    "    w2.zoom_level = w1.zoom_level\n",
+    "\n",
+    "button_zoomlevel.on_click(on_button_zoomlevel_clicked)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "VBox([HBox([VBox([label1, w1, dropdown1], layout=Layout(margin='0 10px 0 0')),\n",
+    "            VBox([label2, w2, dropdown2])]),\n",
+    "      button_zoomlevel,\n",
+    "      statusmsg])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Instructions\n",
+    "\n",
+    "Load images by selecting them from the respective dropdown menus for the viewers.\n",
+    "\n",
+    "Click on the left viewer and the right one will match in RA and Dec of centered point. No distortion correction is performed at this point.\n",
+    "\n",
+    "Press `+`/`-` to zoom in/out. Click \"Sync zoom level\" button to have the right viewer match the zoom level of the left one."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example_notebooks/linked_wcs_2_windows.ipynb
+++ b/example_notebooks/linked_wcs_2_windows.ipynb
@@ -65,7 +65,8 @@
     "        num_images = 10  # Max images in cache; should user be able to set this?\n",
     "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
     "        self._other_viewer = None\n",
-    "        \n",
+    "\n",
+    "    # Need jwst package.\n",
     "    def load_jwst_asdf(self, filename):\n",
     "        if filename in self.datasrc:\n",
     "            image = self.datasrc[filename]\n",
@@ -143,9 +144,9 @@
    "source": [
     "fits_files = [\n",
     "    'N/A',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']"
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00003_nrca5_assign_wcs.fits']"
    ]
   },
   {
@@ -260,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/example_notebooks/linked_wcs_blink.ipynb
+++ b/example_notebooks/linked_wcs_blink.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use case: 1 window to \"blink\" 2 candidates manually with a \"hot key.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from ipywidgets import Button, Label, VBox, HBox\n",
+    "from ipyevents import Event\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "from ginga.misc import Datasrc\n",
+    "from ginga.misc.log import get_logger\n",
+    "from ginga.util import wcsmod\n",
+    "from ginga.util.iohelper import get_fileinfo\n",
+    "\n",
+    "from astrowidgets import ImageWidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading ASDF in Ginga needs this to be specified early on\n",
+    "wcsmod.use('astropy_ape14')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = get_logger('my viewer', log_stderr=True, log_file=None, level=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BlinkImageWidget(ImageWidget):\n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        num_images = 10  # Max images in cache; should user be able to set this?\n",
+    "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
+    "        self._saved_skycoord = None\n",
+    "        self._saved_zoom_level = None\n",
+    "\n",
+    "    def load_jwst_asdf(self, filename):\n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "        else:\n",
+    "            import asdf\n",
+    "            from ginga.AstroImage import AstroImage\n",
+    "\n",
+    "            image = AstroImage(logger=self.logger)\n",
+    "            image.load_file(filename, data_key='data')\n",
+    "\n",
+    "            self.datasrc[filename] = image\n",
+    "\n",
+    "        self._viewer.set_image(image)\n",
+    "        \n",
+    "    def load_fits(self, filename):\n",
+    "        bnch = get_fileinfo(filename)\n",
+    "        \n",
+    "        if filename in self.datasrc:\n",
+    "            image = self.datasrc[filename]\n",
+    "            self._viewer.set_image(image)\n",
+    "        else:\n",
+    "            super().load_fits(bnch.filepath, numhdu=bnch.numhdu)\n",
+    "            self.datasrc[filename] = self._viewer.get_image()\n",
+    "\n",
+    "    def _mouse_click_cb(self, viewer, event, data_x, data_y):\n",
+    "        image = viewer.get_image()\n",
+    "        if image is None:  # Nothing to do\n",
+    "            return\n",
+    "\n",
+    "        if image.wcs.wcs is not None:\n",
+    "            ra, dec = image.pixtoradec(data_x, data_y)\n",
+    "            self._saved_skycoord = SkyCoord(ra, dec, unit='deg')\n",
+    "\n",
+    "        super()._mouse_click_cb(self._viewer, event, data_x, data_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w1 = BlinkImageWidget(logger=logger)\n",
+    "w1.click_center = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fits_files = [\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
+    "n_files = len(fits_files)\n",
+    "i_file = None  # This counter will be updated by button"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label1 = Label('Filename')\n",
+    "button1 = Button(description=\"Next image\")\n",
+    "button2 = Button(description=\"Set zoom level\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_image(i_file):\n",
+    "    filename = fits_files[i_file]\n",
+    "    label1.value = os.path.basename(filename)\n",
+    "    # w1.load_fits(filename)  # FITS\n",
+    "    w1.load_jwst_asdf(filename)  # JWST ASDF-in-FITS\n",
+    "\n",
+    "    # Jump to saved coordinates\n",
+    "    image = w1._viewer.get_image()\n",
+    "    if image.wcs.wcs is not None and isinstance(w1._saved_skycoord, SkyCoord):\n",
+    "        w1.center_on(w1._saved_skycoord)\n",
+    "    if w1._saved_zoom_level is not None:\n",
+    "        w1.zoom_level = w1._saved_zoom_level\n",
+    "\n",
+    "d = Event(source=button1, watched_events=['click', 'keydown', 'mouseenter'])\n",
+    "\n",
+    "def handle_event(event):\n",
+    "    global i_file\n",
+    "    event_type = event['type']\n",
+    "    go_forward = None\n",
+    "\n",
+    "    if event_type == 'keydown':\n",
+    "        event_key = event['key']\n",
+    "        if event_key == 'ArrowRight':\n",
+    "            go_forward = True\n",
+    "        elif event_key == 'ArrowLeft':\n",
+    "            go_forward = False\n",
+    "    elif event_type == 'click':\n",
+    "        go_forward = True\n",
+    "\n",
+    "    if go_forward is None:  # Nothing to do\n",
+    "        return\n",
+    "\n",
+    "    if i_file is None:\n",
+    "        i_file = 0\n",
+    "    elif go_forward:\n",
+    "        i_file = (i_file + 1) % n_files\n",
+    "    else:\n",
+    "        i_file = (i_file - 1) % n_files\n",
+    "\n",
+    "    load_image(i_file)\n",
+    "        \n",
+    "d.on_dom_event(handle_event)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def on_button2_clicked(b):\n",
+    "    w1._saved_zoom_level = w1.zoom_level\n",
+    "\n",
+    "button2.on_click(on_button2_clicked)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "VBox([label1, w1, HBox([button1, button2])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Click \"Next image\" to start blinking. Alternately, you can also mouse over \"Next image\" and use the left/right arrow keys instead.\n",
+    "\n",
+    "Use `+` or `-` to zoom to the desired zoom level and click \"Set zoom level\" to save it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example_notebooks/linked_wcs_blink.ipynb
+++ b/example_notebooks/linked_wcs_blink.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from ipywidgets import Button, Label, VBox, HBox\n",
+    "from ipywidgets import Label, VBox\n",
     "from ipyevents import Event\n",
     "\n",
     "from astropy.coordinates import SkyCoord\n",
@@ -58,9 +58,8 @@
     "        super().__init__(*args, **kwargs)\n",
     "        num_images = 10  # Max images in cache; should user be able to set this?\n",
     "        self.datasrc = Datasrc.Datasrc(num_images)  # Cache\n",
-    "        self._saved_skycoord = None\n",
-    "        self._saved_zoom_level = None\n",
     "\n",
+    "    # Need jwst package to be installed.\n",
     "    def load_jwst_asdf(self, filename):\n",
     "        if filename in self.datasrc:\n",
     "            image = self.datasrc[filename]\n",
@@ -83,18 +82,7 @@
     "            self._viewer.set_image(image)\n",
     "        else:\n",
     "            super().load_fits(bnch.filepath, numhdu=bnch.numhdu)\n",
-    "            self.datasrc[filename] = self._viewer.get_image()\n",
-    "\n",
-    "    def _mouse_click_cb(self, viewer, event, data_x, data_y):\n",
-    "        image = viewer.get_image()\n",
-    "        if image is None:  # Nothing to do\n",
-    "            return\n",
-    "\n",
-    "        if image.wcs.wcs is not None:\n",
-    "            ra, dec = image.pixtoradec(data_x, data_y)\n",
-    "            self._saved_skycoord = SkyCoord(ra, dec, unit='deg')\n",
-    "\n",
-    "        super()._mouse_click_cb(self._viewer, event, data_x, data_y)"
+    "            self.datasrc[filename] = self._viewer.get_image()"
    ]
   },
   {
@@ -104,7 +92,11 @@
    "outputs": [],
    "source": [
     "w1 = BlinkImageWidget(logger=logger)\n",
-    "w1.click_center = True"
+    "w1.click_center = True\n",
+    "\n",
+    "# Autozoom and autocenter only for the first time.\n",
+    "w1._viewer.enable_autozoom('once')\n",
+    "w1._viewer.enable_autocenter('once')"
    ]
   },
   {
@@ -114,9 +106,9 @@
    "outputs": [],
    "source": [
     "fits_files = [\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
-    "    'D:\\\\PLLIM\\\\STScI\\\\ssb\\\\test_data\\\\jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00001_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00002_nrca5_assign_wcs.fits',\n",
+    "    '/redkeep/ironthrone/ssb/stginga/test_data/jw42424001001_01101_00003_nrca5_assign_wcs.fits']\n",
     "n_files = len(fits_files)\n",
     "i_file = None  # This counter will be updated by button"
    ]
@@ -127,9 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "label1 = Label('Filename')\n",
-    "button1 = Button(description=\"Next image\")\n",
-    "button2 = Button(description=\"Set zoom level\")"
+    "label1 = Label('Filename')"
    ]
   },
   {
@@ -139,59 +129,64 @@
    "outputs": [],
    "source": [
     "def load_image(i_file):\n",
+    "    # Get data off the current image before switching\n",
+    "    image = w1._viewer.get_image()\n",
+    "    data_x = None\n",
+    "    saved_skycoord = None\n",
+    "    saved_zoom_level = None\n",
+    "    if image is not None:\n",
+    "        saved_zoom_level = w1.zoom_level\n",
+    "        data_x, data_y = w1._viewer.get_data_xy(*w1._viewer.get_center())\n",
+    "        try:\n",
+    "            ra, dec = image.pixtoradec(data_x, data_y)\n",
+    "            saved_skycoord = SkyCoord(ra, dec, unit='deg')\n",
+    "        except Exception:\n",
+    "            pass\n",
+    "\n",
     "    filename = fits_files[i_file]\n",
     "    label1.value = os.path.basename(filename)\n",
     "    # w1.load_fits(filename)  # FITS\n",
     "    w1.load_jwst_asdf(filename)  # JWST ASDF-in-FITS\n",
     "\n",
-    "    # Jump to saved coordinates\n",
     "    image = w1._viewer.get_image()\n",
-    "    if image.wcs.wcs is not None and isinstance(w1._saved_skycoord, SkyCoord):\n",
-    "        w1.center_on(w1._saved_skycoord)\n",
-    "    if w1._saved_zoom_level is not None:\n",
-    "        w1.zoom_level = w1._saved_zoom_level\n",
+    "    \n",
+    "    # Center at the same place as primary viewer\n",
+    "    if data_x:\n",
+    "        center_by_xy = True\n",
+    "        if saved_skycoord and image.wcs.wcs:\n",
+    "            try:\n",
+    "                w1.center_on(saved_skycoord)\n",
+    "            except Exception:\n",
+    "                pass\n",
+    "            else:\n",
+    "                center_by_xy = False\n",
+    "        if center_by_xy:\n",
+    "            w1.center_on((data_x, data_y))\n",
     "\n",
-    "d = Event(source=button1, watched_events=['click', 'keydown', 'mouseenter'])\n",
+    "    if saved_zoom_level:\n",
+    "        w1.zoom_level = saved_zoom_level\n",
+    "\n",
     "\n",
     "def handle_event(event):\n",
     "    global i_file\n",
-    "    event_type = event['type']\n",
-    "    go_forward = None\n",
     "\n",
-    "    if event_type == 'keydown':\n",
-    "        event_key = event['key']\n",
-    "        if event_key == 'ArrowRight':\n",
-    "            go_forward = True\n",
-    "        elif event_key == 'ArrowLeft':\n",
-    "            go_forward = False\n",
-    "    elif event_type == 'click':\n",
-    "        go_forward = True\n",
-    "\n",
-    "    if go_forward is None:  # Nothing to do\n",
+    "    if event['type'] != 'keydown':\n",
     "        return\n",
-    "\n",
+    "    \n",
     "    if i_file is None:\n",
     "        i_file = 0\n",
-    "    elif go_forward:\n",
+    "    elif event['key'] == 'ArrowRight':\n",
     "        i_file = (i_file + 1) % n_files\n",
-    "    else:\n",
+    "    elif event['key'] == 'ArrowLeft':\n",
     "        i_file = (i_file - 1) % n_files\n",
+    "    else:\n",
+    "        return\n",
     "\n",
     "    load_image(i_file)\n",
-    "        \n",
-    "d.on_dom_event(handle_event)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def on_button2_clicked(b):\n",
-    "    w1._saved_zoom_level = w1.zoom_level\n",
     "\n",
-    "button2.on_click(on_button2_clicked)"
+    "\n",
+    "d = Event(source=w1, watched_events=['keydown'])\n",
+    "d.on_dom_event(handle_event)"
    ]
   },
   {
@@ -202,16 +197,14 @@
    },
    "outputs": [],
    "source": [
-    "VBox([label1, w1, HBox([button1, button2])])"
+    "VBox([label1, w1])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Click \"Next image\" to start blinking. Alternately, you can also mouse over \"Next image\" and use the left/right arrow keys instead.\n",
-    "\n",
-    "Use `+` or `-` to zoom to the desired zoom level and click \"Set zoom level\" to save it."
+    "You can mouse over the image display widget and use the left/right arrow keys to blink."
    ]
   }
  ],
@@ -231,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix #62 

* `linked_wcs_2_windows.ipynb` addresses the **2 linked windows with "a hundred" candidates to load for each** use case in #62 
  * Caveat: I don't have a hundred files on disk to test this with, but the machinery is in place if you want to try load 100 files into the notebook...
  * Caching was added to this PR in subsequent commit.
* `linked_wcs_blink.ipynb` addresses the **1 window to "blink" 2 candidates manually with a "hot key"** use case in #62 (caching using `Datasrc` is also added, xref #108)
* `linked_wcs_12_windows.ipynb` addressed the **12 linked windows with one candidate loaded for each** use case in #62 (also with caching)
  * Caveat: I only have 3 files, so I repeatedly use them to fill all 12 viewers.

cc @hcferguson and @larrybradley

Data files used available from https://stsci.app.box.com/folder/3381606676 (special permission required).

**TODO**

- [x] Load simulated calibrated dithered NIRCam images provided by @bhilbert4 (ASDF in FITS).
- [x] Implement caching for `linked_wcs_2_windows.ipynb`.
- [x] See if there is anything we can do to mitigation a visual jump when blinking in `linked_wcs_blink.ipynb`. (Nope. But maybe not critical as it gives visual queue that new image is being displayed.)
- [x] Stretch goal: Implement a third notebook addressing "12 linked windows with one candidate loaded for each" use case in #62 

## Screenshots

### linked_wcs_blink.ipynb

![Screenshot_blink_wcs](https://user-images.githubusercontent.com/2090236/106206705-86d09900-618e-11eb-8bfe-892282008fd8.jpg)

### linked_wcs_2_windows.ipynb

![Screenshot_link_2_wcs](https://user-images.githubusercontent.com/2090236/106206719-8c2de380-618e-11eb-863b-9fc15008637e.jpg)

### linked_wcs_12_windows.ipynb

![Screenshot_12_monkeys](https://user-images.githubusercontent.com/2090236/106206731-905a0100-618e-11eb-8014-54d7a95696b9.jpg)
