### PR TITLE
Ignore RA/Dec string formatting failures

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -214,7 +214,8 @@ class ImageWidget(ipyw.VBox):
                     val += ' (RA: {}, DEC: {})'.format(
                         raDegToString(ra), decDegToString(dec))
                 except Exception:
-                    pass
+                    val += ' (RA, DEC: WCS error)'
+
             val += ', value: {}'.format(imval)
             self._jup_coord.value = val
 

--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -209,9 +209,12 @@ class ImageWidget(ipyw.VBox):
             val = 'X: {:.2f}, Y: {:.2f}'.format(data_x + self._pixel_offset,
                                                 data_y + self._pixel_offset)
             if image.wcs.wcs is not None:
-                ra, dec = image.pixtoradec(data_x, data_y)
-                val += ' (RA: {}, DEC: {})'.format(
-                    raDegToString(ra), decDegToString(dec))
+                try:
+                    ra, dec = image.pixtoradec(data_x, data_y)
+                    val += ' (RA: {}, DEC: {})'.format(
+                        raDegToString(ra), decDegToString(dec))
+                except Exception:
+                    pass
             val += ', value: {}'.format(imval)
             self._jup_coord.value = val
 


### PR DESCRIPTION
While working with #110, I found that invalid WCS causes the cursor info bar to not display at all, when the values raises `AssertionError` in Ginga. I find that it makes more sense to display info bar anyway without RA and Dec, when WCS conversion fails for whatever reason, instead to just not work.