### PR TITLE
[EXP] CANDELS big mosaic visualization

### DIFF
--- a/example_notebooks/big_mosaic.ipynb
+++ b/example_notebooks/big_mosaic.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example visualizing a big mosaic image with astrowidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "from ginga.misc.log import get_logger\n",
+    "\n",
+    "from astrowidgets import ImageWidget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can download this file from https://archive.stsci.edu/pub/hlsp/candels/goods-s/gs-tot/v1.0/hlsp_candels_hst_wfc3_gs-tot_f160w_v1.0_drz.fits. It is a 30k by 40k big CANDELS mosaic that is 4.9 GB.\n",
+    "\n",
+    "    Filename: hlsp_candels_hst_wfc3_gs-tot_f160w_v1.0_drz.fits\n",
+    "    No.    Name      Ver    Type      Cards   Dimensions   Format\n",
+    "    0   PRIMARY      1 PrimaryHDU     151   (32400, 40500) float32"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = '/redkeep/ironthrone/ssb/stginga/test_data/hlsp_candels_hst_wfc3_gs-tot_f160w_v1.0_drz.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = get_logger('my viewer', log_stderr=True, log_file=None, level=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = ImageWidget(logger=logger)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.load_fits(filename, memmap=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Change the colormap, stretch, and cuts. Modify the parameters below to suit your data if you are using your own data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.set_colormap('viridis')\n",
+    "w.stretch = 'linear'\n",
+    "w.cuts = (-0.01, 0.25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Center on the object of interest and zoom in. Again, modify the parameters below as you see fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = SkyCoord('03h32m19.128s', '-27d47m59.52s')\n",
+    "w.center_on(c)\n",
+    "w.zoom_level = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The conclusion from this exercise is that at least when using `astrowidgets` with the Ginga backend, no special code is necessary to support the visualization of a very big mosaic image."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook is an example to visualize a CANDELS mosaic image that is a single-extension FITS with the file size of 4.9 GB. The conclusion of this exercise is that I think Ginga can handle big mosaic natively as-is. I am not sure if this PR needs to be merged; I opened this so others can play around with this notebook on different machines and report back any problems. I did not notice any spikes in memory usage; I think the `memmap` helps a lot here.

p.s. Similar conclusion for Ginga standalone GUI but I did not try using all the plugins on this data, just `Pick` and `Histogram`.

cc @hcferguson

**Example screenshot**

![Screenshot from 2020-02-18 11-41-54](https://user-images.githubusercontent.com/2090236/74757831-891f3900-5244-11ea-8974-66f7722ea512.png)