### PR TITLE
ENH: Add example to draw WCS axes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,9 @@ matrix:
 
         - stage: Comprehensive tests
           os: windows
+          env: PYTHON_VERSION=3.8
+               MAIN_CMD="pytest astrowidgets"
+               SETUP_CMD=''
 
         # Do a PEP8 test with flake8
         - stage: Comprehensive tests

--- a/example_notebooks/ginga_wcsaxes.ipynb
+++ b/example_notebooks/ginga_wcsaxes.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Drawing WCS Axes with Ginga"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See https://astrowidgets.readthedocs.io for additional details about the widget, including installation notes.\n",
+    "\n",
+    "Also see https://ginga.readthedocs.io/en/stable/manual/plugins_local/wcsaxes.html for the Reference Viewer (standalone GUI) plugin that this notebook is based on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.nddata import CCDData\n",
+    "from astrowidgets import ImageWidget as _ImageWidget\n",
+    "from ginga.canvas.types.astro import WCSAxes\n",
+    "from ginga.misc.log import get_logger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = get_logger('my viewer', log_stderr=True,\n",
+    "                    log_file=None, level=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ImageWidget(_ImageWidget):\n",
+    "    \"\"\"Extends core widget to handle WCS axes.\"\"\"\n",
+    "    \n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        self.axes_tag = 'widget_wcsaxes'\n",
+    "    \n",
+    "    def draw_wcs_axes(self, linewidth=1, linestyle='solid', linecolor='cyan',\n",
+    "                      alpha=1, fontsize=8, n_ra_lines=10, n_dec_lines=10,\n",
+    "                      show_label=True, label_offset=4, ra_angle=None, dec_angle=None):\n",
+    "        \"\"\"Draw or update WCS axes. Axes properties are same as those in\n",
+    "        https://ginga.readthedocs.io/en/stable/manual/plugins_local/wcsaxes.html ,\n",
+    "        except for ``ra_angle`` and ``dec_angle``.\n",
+    "        \n",
+    "        * ``linestyle`` can be 'solid' or 'dash'.\n",
+    "        * ``ra_angle`` and ``dec_angle`` control the angles, in degrees,\n",
+    "          of RA and Dec labels, respectively. In the standalone GUI plugin,\n",
+    "          their controls were available via plugin GUI only and not settable\n",
+    "          from configuration file.\n",
+    "        \n",
+    "        \"\"\"\n",
+    "        try:\n",
+    "            axes = self._viewer.canvas.get_object_by_tag(self.axes_tag)\n",
+    "        except Exception:  # Draw new\n",
+    "            axes = WCSAxes(linewidth=linewidth, linestyle=linestyle, color=linecolor,\n",
+    "                           alpha=alpha, fontsize=fontsize)\n",
+    "            axes.num_ra = n_ra_lines\n",
+    "            axes.num_dec = n_dec_lines\n",
+    "            axes.show_label = show_label\n",
+    "            axes.txt_off = label_offset\n",
+    "            axes.ra_angle = ra_angle\n",
+    "            axes.dec_angle = dec_angle\n",
+    "            self._viewer.canvas.add(axes, tag=self.axes_tag)\n",
+    "        else:  # Update existing\n",
+    "            axes.linewidth = linewidth\n",
+    "            axes.linestyle = linestyle\n",
+    "            axes.color = linecolor\n",
+    "            axes.alpha = alpha\n",
+    "            axes.fontsize = fontsize\n",
+    "            axes.num_ra = n_ra_lines\n",
+    "            axes.num_dec = n_dec_lines\n",
+    "            axes.show_label = show_label\n",
+    "            axes.txt_off = label_offset\n",
+    "            axes.ra_angle = ra_angle\n",
+    "            axes.dec_angle = dec_angle\n",
+    "            axes.sync_state()\n",
+    "            w._viewer.canvas.update_canvas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = ImageWidget(logger=logger)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this example, we use an image from the Astropy Data Server and load it as `CCDData`. Feel free to modify `filename` to point to your desired image. It is important that the image has a valid WCS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = 'https://github.com/astropy/astropy-data/raw/gh-pages/galactic_center/gc_2mass_k.fits'\n",
+    "numhdu = 0\n",
+    "fluxunit = 'count'\n",
+    "\n",
+    "ccd = CCDData.read(filename, hdu=numhdu, unit=fluxunit, format='fits')\n",
+    "print(ccd.wcs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.load_nddata(ccd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.stretch = 'asinh'\n",
+    "w.cuts = 'histogram'\n",
+    "w.set_colormap('viridis')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following line draws WCS axes on the display widget above using the default settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.draw_wcs_axes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This updates the WCS axes with a non-default setting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.draw_wcs_axes(linecolor='pink', fontsize=14)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/example_notebooks/ginga_wcsaxes.ipynb
+++ b/example_notebooks/ginga_wcsaxes.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "w.stretch = 'asinh'\n",
     "w.cuts = 'histogram'\n",
-    "w.set_colormap('viridis')"
+    "w.set_colormap('ds9_cool')"
    ]
   },
   {


### PR DESCRIPTION
Not sure if you want to merge this or not but I got it to work. Thanks to @ejeschke's foresight in the canvas drawing design, it was easier to port than I thought! Also see https://ginga.readthedocs.io/en/latest/manual/plugins_local/wcsaxes.html

Fix #79

cc @jdavies-st

**Example screenshot**

![astrowidget_wcsaxes](https://user-images.githubusercontent.com/2090236/87480760-fe2c4a00-c5fb-11ea-9d15-aa62147b72fc.jpg)

p.s. I didn't spend a lot of time to tweak the WCS axes layout parameters to make it perfect but it can be done.