### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@main
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/astrowidgets/index.rst
+++ b/docs/astrowidgets/index.rst
@@ -63,8 +63,8 @@ A more detailed description of the interface and the :ref:`api-docs` are availab
 Example Notebooks
 -----------------
 
-* `astrowidgets using the Ginga backend <https://github.com/astropy/astrowidgets/blob/master/example_notebooks/ginga_widget.ipynb>`_
-* `Using named markers to keep track of logically related markers <https://github.com/astropy/astrowidgets/blob/master/example_notebooks/named_markers.ipynb>`_
-* `Demonstration of GUI interactions <https://github.com/astropy/astrowidgets/blob/master/example_notebooks/gui_interactions.ipynb>`_
+* `astrowidgets using the Ginga backend <https://github.com/astropy/astrowidgets/blob/main/example_notebooks/ginga_widget.ipynb>`_
+* `Using named markers to keep track of logically related markers <https://github.com/astropy/astrowidgets/blob/main/example_notebooks/named_markers.ipynb>`_
+* `Demonstration of GUI interactions <https://github.com/astropy/astrowidgets/blob/main/example_notebooks/gui_interactions.ipynb>`_
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 #     if versionmod.version.release:
 #         edit_on_github_branch = "v" + versionmod.version.version
 #     else:
-#         edit_on_github_branch = "master"
+#         edit_on_github_branch = "main"
 
 #     edit_on_github_source_root = ""
 #     edit_on_github_doc_root = "docs"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,7 +62,7 @@ should be sufficient unless stated otherwise.
 Using OpenCV
 ------------
 
-If you wish to use `OpenCV <https://docs.opencv.org/master/index.html>`_ to handle the
+If you wish to use `OpenCV <https://docs.opencv.org/main/index.html>`_ to handle the
 drawing in Ginga, you have two options:
 
 Install OpenCV with pip


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.