### PR TITLE
MNT: Do not use enable_deprecations_as_exceptions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 # Set the version of Python and requirements required to build your docs
 python:
   version: 3.8
-  system_packages: true
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/astrowidgets/conftest.py
+++ b/astrowidgets/conftest.py
@@ -7,11 +7,6 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions.
-# from astropy.tests.helper import enable_deprecations_as_exceptions
-# enable_deprecations_as_exceptions()
-
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running
 # the tests. Making it pass for KeyError is essential in some cases when

--- a/conftest.py
+++ b/conftest.py
@@ -7,11 +7,6 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions.
-# from astropy.tests.helper import enable_deprecations_as_exceptions
-# enable_deprecations_as_exceptions()
-
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running
 # the tests. Making it pass for KeyError is essential in some cases when


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .