### PR TITLE
MNT: Compatibility with Ginga v4

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -19,7 +19,7 @@ import ipywidgets as ipyw
 from ginga.AstroImage import AstroImage
 from ginga.canvas.CanvasObject import drawCatalog
 from ginga.web.jupyterw.ImageViewJpw import EnhancedCanvasView
-from ginga.util.wcs import raDegToString, decDegToString
+from ginga.util.wcs import ra_deg_to_str, dec_deg_to_str
 
 __all__ = ['ImageWidget']
 
@@ -214,7 +214,7 @@ class ImageWidget(ipyw.VBox):
                 try:
                     ra, dec = image.pixtoradec(data_x, data_y)
                     val += ' (RA: {}, DEC: {})'.format(
-                        raDegToString(ra), decDegToString(dec))
+                        ra_deg_to_str(ra), dec_deg_to_str(dec))
                 except Exception:
                     val += ' (RA, DEC: WCS error)'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = False
 packages = find:
 install_requires =
     astropy
-    ginga
+    ginga>=3.4
     pillow
     ipywidgets>=7.5
     ipyevents>=0.6.3


### PR DESCRIPTION
There was a bunch of API deprecated/removed for upcoming Ginga v4.0. One of those failed the devdeps job here. This will make the CI green again.

This PR also specifies a theoretical minversion for Ginga.