### PR TITLE
MNT: Un-ignore ioloop DeprecationWarning from Ginga

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ filterwarnings =
     ignore:zmq\.eventloop\.ioloop is deprecated in pyzmq 17:DeprecationWarning
     ignore:Widget.* is deprecated:DeprecationWarning
     ignore:Marker set named:UserWarning
-    # https://github.com/ejeschke/ginga/issues/1033
-    ignore:There is no current event loop:DeprecationWarning
 
 [flake8]
 # E501: line too long


### PR DESCRIPTION
The warning had been resolved by test https://github.com/ejeschke/ginga/pull/1037