### PR TITLE
Fix test for stretch

### DIFF
--- a/astrowidgets/core.py
+++ b/astrowidgets/core.py
@@ -814,7 +814,7 @@ class ImageWidget(ipyw.VBox):
         """
         The image stretching algorithm in use.
         """
-        return self._viewer.rgbmap.dist
+        return self._viewer.rgbmap.get_dist()
 
     # TODO: Possible to use astropy.visualization directly?
     @stretch.setter


### PR DESCRIPTION
- fix #159
- fixes test for "stretch"; use method API to fetch the distribution object rather than accessing instance variable