### PR TITLE
Add overwrite argument to save method

### DIFF
--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -2,6 +2,7 @@
 
 # STDLIB
 import functools
+from pathlib import Path
 import warnings
 
 # THIRD-PARTY
@@ -973,12 +974,23 @@ class ImageWidget(ipyw.VBox):
         else:
             bindmap.map_event(None, (), 'pa_pan', 'zoom')
 
-    def save(self, filename):
+    def save(self, filename, overwrite=False):
         """
         Save out the current image view to given PNG filename.
+
+        Parameters
+        ----------
+        filename : str
+            Name of file to save to.
+
+        overwrite : bool, optional
+            If `True`, overwrite existing file.
         """
         # It turns out the image value is already in PNG format so we just
         # to write that out to a file.
+        if not overwrite and Path.exists(filename):
+            raise FileExistsError(f'File {filename} exists and overwrite=False')
+
         with open(filename, 'wb') as f:
             f.write(self._jup_img.value)
 

--- a/astrowidgets/interface_definition.py
+++ b/astrowidgets/interface_definition.py
@@ -90,7 +90,7 @@ class ImageViewerInterface(Protocol):
 
     # Saving contents of the view and accessing the view
     @abstractmethod
-    def save(self, filename: str | os.PathLike) -> None:
+    def save(self, filename: str | os.PathLike, overwrite: bool = False) -> None:
         """
         Save the current view to a file.
 
@@ -99,6 +99,10 @@ class ImageViewerInterface(Protocol):
         filename : str
             The file to save to. The format is determined by the
             extension.
+
+        overwrite : bool, optional
+            If `True`, overwrite the file if it exists. Default is
+            `False`.
         """
         raise NotImplementedError
 

--- a/astrowidgets/tests/widget_api_test.py
+++ b/astrowidgets/tests/widget_api_test.py
@@ -359,3 +359,16 @@ class ImageWidgetAPITest:
     def test_save(self, tmp_path):
         filename = tmp_path / 'woot.png'
         self.image.save(filename)
+
+    def test_save_overwrite(self, tmp_path):
+        filename = tmp_path / 'woot.png'
+
+        # First write should be fine
+        self.image.save(filename)
+
+        # Second write should raise an error because file exists
+        with pytest.raises(FileExistsError):
+            self.image.save(filename)
+
+        # Using overwrite should save successfully
+        self.image.save(filename, overwrite=True)


### PR DESCRIPTION
I was discussing astrowidgets with a colleague who pointed out that, by default, `astrowidgets` silently overwrites files when it saves. This PR adds an `overwrite` argument to the `save` method and implements it in the ginga viewer. I'm hoping this is uncontroversial enough that it can be approveed/merged without a synchronous discussion 😀