### PR TITLE
Remove dead click-handler code so clicks do not raise AttributeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,3 +2,12 @@
 ================
 
 TBD -- First stable release.
+
+Bug Fixes
+---------
+
+- Fixed the bqplot ``ImageWidget`` so that mouse clicks no longer raise
+  ``AttributeError`` and no longer block user-registered ``on_msg``
+  callbacks. The dead click-to-center and interactive-marking code left
+  over from before the switch to ``astro-image-display-api`` was removed;
+  those features will be rebuilt (see #201). [#206]

--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -414,8 +414,6 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         # debugging.
         self._print_out = ipw.Output()
 
-        self.marker = {'color': 'red', 'radius': 20, 'type': 'square'}
-
         self._cursor = ipw.HTML('Coordinates show up here')
 
         self._init_mouse_callbacks()
@@ -475,34 +473,11 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
             # Nothing to display, so exit
             return
 
-        xc = event_data['domain']['x']
-        yc = event_data['domain']['y']
-
-        if self.click_center:
-            self.center_on((xc, yc))
-
-        if self.is_marking:
-            print('marky marking')
-            # Just hand off to the method that actually does the work
-            self._add_new_single_marker(xc, yc)
-
-    def _add_new_single_marker(self, x_mark, y_mark):
-        # We have location of the new marker and should have the name
-        # of the marker tag and the marker style, so just need to update
-        # the table and draw the new maker.
-
-        marker_name = self._marker_table._interactive_marker_set_name
-        # update the marker table
-        self._marker_table.add_markers([x_mark], [y_mark], marker_name=marker_name)
-
-        # First approach: get any current markers by that name, add this one
-        # remove the old ones and draw the new ones.
-        marks = self.get_markers(marker_name=marker_name)
-        self._astro_im.plot_named_markers(marks['x'], marks['y'],
-                                          marker_name,
-                                          color=self.marker['color'],
-                                          size=self.marker['radius']**2,
-                                          shape=self.marker['type'])
+        # Interactive click features (click-to-center, interactive marking)
+        # were removed in the migration to the astro-image-display-api and
+        # will be rebuilt, see #201. Until then this is intentionally a
+        # no-op so that clicks do not raise and user-registered on_msg
+        # callbacks still run.
 
     # Update the viewport to match changes in the UI
     def _init_watch_image_changes(self):

--- a/astrowidgets/tests/test_widget_api_bqplot.py
+++ b/astrowidgets/tests/test_widget_api_bqplot.py
@@ -18,6 +18,33 @@ def test_instance():
     assert isinstance(image, ImageViewerInterface)
 
 
+def test_mouse_click_does_not_raise_or_block_callbacks():
+    # Regression test for #206: the built-in click handler referenced
+    # attributes that no longer exist, so any click raised AttributeError
+    # and, because ipywidgets runs on_msg callbacks in registration order
+    # with no exception isolation, blocked user-registered callbacks.
+    image = ImageWidget()
+
+    # A click before any image is loaded should be a no-op.
+    image._mouse_click({'domain': {'x': 3, 'y': 3}})
+
+    image.load_image(np.zeros((10, 10)))
+
+    calls = []
+
+    def user_callback(interaction, event_data, buffers):
+        calls.append(event_data)
+
+    image._astro_im.interaction.on_msg(user_callback)
+
+    # Simulate the comm message a real mouse click produces; this invokes
+    # all registered on_msg callbacks in order, built-in handler first.
+    click_event = {'event': 'click', 'domain': {'x': 3, 'y': 3}}
+    image._astro_im.interaction._handle_custom_msg(click_event, [])
+
+    assert calls == [click_event]
+
+
 class TestBQplotWidget(ImageAPITest):
     image_widget_class = ImageWidget
     cursor_error_classes = (ValueError, TraitError)


### PR DESCRIPTION
Fixes #206

Any mouse click on the bqplot `ImageWidget` with an image loaded raised `AttributeError` because `_mouse_click` referenced `click_center` and `is_marking`, which were never initialized. Because ipywidgets runs `on_msg` callbacks in registration order without exception isolation, the error also blocked all user-registered click callbacks.

The branches turned out to be dead beyond the missing flags: `center_on()`, `get_markers()`, and `_marker_table` belong to the pre-AIDA API and no longer exist anywhere in the bqplot backend or `ImageViewerLogic`, so even initializing the flags to `False` would have left code that crashes the moment either flag is set to `True`.

Changes:
- `_mouse_click` keeps its no-image guard but is otherwise an intentional no-op, with a comment pointing at #201 for the planned rebuild of click-to-center and interactive marking. The click dispatch in `on_mouse_message` stays in place so the rebuild just fills the method back in.
- Removed `_add_new_single_marker` and the `self.marker` dict, whose only consumers were the dead branches.
- Added a regression test that simulates a click comm message via `interaction._handle_custom_msg` and asserts nothing raises and a downstream `on_msg` callback still runs.
- Changelog entry under 1.0 (unreleased).

All bqplot API tests pass (52 passed, 2 browser-dependent save tests skipped), the issue's reproducer no longer raises, and flake8 is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4nre7DQt2HuQRUdRXXM6S