### PR TITLE
Slim the ginga backend to AIDA rendering hooks

### DIFF
--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -23,7 +23,7 @@ from ginga.canvas.CanvasObject import drawCatalog
 from ginga.web.jupyterw.ImageViewJpw import EnhancedCanvasView
 from ginga.util.wcs import ra_deg_to_str, dec_deg_to_str
 
-from astro_image_display_api.image_viewer_logic import ImageViewerLogic
+from astro_image_display_api import ImageViewerLogic, docs_from_super_if_missing
 
 __all__ = ['ImageWidget']
 
@@ -159,34 +159,6 @@ def _ginga_dist_for_stretch(stretch, hashsize):
             return _AstropyStretchDist(hashsize, stretch)
 
 
-def docs_from_super_if_missing(cls):
-    """
-    Class decorator that fills in missing docstrings from the AIDA interface.
-
-    Public methods of the decorated class that lack a docstring receive the
-    docstring of the same-named method on
-    `~astro_image_display_api.image_viewer_logic.ImageViewerLogic`.
-
-    Parameters
-    ----------
-    cls : type
-        The class being decorated.
-
-    Returns
-    -------
-    type
-        The same class, with missing docstrings filled in.
-    """
-    for name, method in cls.__dict__.items():
-        if not name.startswith("_"):
-            if method.__doc__:
-                continue
-            interface_method = getattr(ImageViewerLogic, name, None)
-            if interface_method:
-                method.__doc__ = interface_method.__doc__
-    return cls
-
-
 # The inheritance order below matters -- VBox needs to come first
 @docs_from_super_if_missing
 class ImageWidget(ipyw.VBox, ImageViewerLogic):
@@ -228,11 +200,6 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         # ImageViewerLogic is a dataclass; we do not run its __init__, so run
         # the post-init hook it would otherwise provide to set up its state.
         ImageViewerLogic.__post_init__(self)
-
-        # Ginga displays a single image at a time; remember which label is on
-        # screen so per-label settings for other images do not touch the
-        # display (see _is_displayed_label).
-        self._displayed_image_label = None
 
         self._viewer = EnhancedCanvasView(logger=logger)
 
@@ -398,57 +365,24 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
                 print('Centered on X={} Y={}'.format(data_x, data_y))
 
     # ------------------------------------------------------------------
-    # Image loading
+    # Image rendering
     # ------------------------------------------------------------------
-    def load_image(self, image, image_label=None, **kwargs):
-        # Let the AIDA logic store the data + WCS and set up the initial
-        # viewport, cuts and stretch in our internal state.
-        super().load_image(image, image_label=image_label, **kwargs)
-
-        # The just-loaded image is now the one on screen.
-        self._displayed_image_label = self._resolve_image_label(image_label)
-
-        # Build a ginga AstroImage from the stored data and show it. The
-        # helpers resolve image_label internally, matching the bqplot backend.
-        data = self.get_image(image_label=image_label)
-        self._viewer.set_image(self._build_ginga_image(data))
-
-        # Apply the stored viewport, cuts, stretch and colormap to the freshly
-        # displayed image.
-        self._apply_viewport_to_ginga(image_label)
-        self._apply_cuts_to_ginga(image_label)
-        self._apply_stretch_to_ginga(image_label)
-        self._apply_colormap_to_ginga(image_label)
-
-    def _is_displayed_label(self, image_label):
+    def _render_image(self, image_label):
         """
-        Whether ``image_label`` refers to the image currently on screen.
+        Show the image stored under a label in the ginga viewer.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic.` ``load_image`` calls it
+        after storing the image data and settings; the ``_apply_*`` hooks are
+        called afterwards to push the stored settings into the display.
 
         Parameters
         ----------
-        image_label : str or None
-            Image label to check, resolved the same way as in the AIDA
-            logic (so `None` is allowed when only one image is loaded).
-
-        Returns
-        -------
-        bool
-            `True` if the label resolves to the displayed image, `False` if
-            it refers to a different image or cannot be resolved.
-
-        Notes
-        -----
-        The ginga viewer shows one image at a time, but the AIDA state stores
-        settings per label. Helpers that push stored state into the live
-        viewer must be skipped when the label refers to a different,
-        not-displayed image; its stored settings are applied when it is next
-        loaded.
+        image_label : str
+            Resolved label of the image to display.
         """
-        try:
-            image_label = self._resolve_image_label(image_label)
-        except ValueError:
-            return False
-        return image_label == self._displayed_image_label
+        data = self.get_image(image_label=image_label)
+        self._viewer.set_image(self._build_ginga_image(data))
 
     def _build_ginga_image(self, data):
         """
@@ -492,25 +426,20 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
     # ------------------------------------------------------------------
     # Cuts / stretch / colormap
     # ------------------------------------------------------------------
-    def set_cuts(self, value, image_label=None, **kwargs):
-        super().set_cuts(value, image_label=image_label, **kwargs)
-        # Changing the cuts only affects the color mapping, so leave the
-        # current viewport (zoom/pan) untouched.
-        self._apply_cuts_to_ginga(image_label)
-
-    def _apply_cuts_to_ginga(self, image_label):
+    def _apply_cuts(self, image_label):
         """
         Push the stored cut levels for a label into the ginga viewer.
 
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed.
+
         Parameters
         ----------
-        image_label : str or None
-            Label whose stored cuts to apply. A no-op unless the label
-            refers to the displayed image.
+        image_label : str
+            Resolved label whose stored cuts to apply.
         """
         ginga_image = self._viewer.get_image()
-        if ginga_image is None or not self._is_displayed_label(image_label):
-            return
         cuts = self.get_cuts(image_label=image_label)
         # get_cuts always returns a BaseInterval, and get_limits computes the
         # concrete low/high for any interval type (percentile, zscale, etc.),
@@ -518,29 +447,22 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         low, high = cuts.get_limits(ginga_image.get_data())
         self._viewer.cut_levels(low, high)
 
-    def set_stretch(self, value, image_label=None, **kwargs):
-        # The astropy stretch (including its shape parameter) is reproduced in
-        # ginga by configuring the matching native color distribution, or, for
-        # stretches ginga lacks a family for, by an astropy-backed adapter.
-        # See _ginga_dist_for_stretch.
-        super().set_stretch(value, image_label=image_label, **kwargs)
-        # Changing the stretch only affects the color mapping, so leave the
-        # current viewport (zoom/pan) untouched.
-        self._apply_stretch_to_ginga(image_label)
-
-    def _apply_stretch_to_ginga(self, image_label):
+    def _apply_stretch(self, image_label):
         """
         Push the stored stretch for a label into the ginga viewer.
 
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed. The astropy stretch (including its shape
+        parameter) is reproduced in ginga by configuring the matching native
+        color distribution, or, for stretches ginga lacks a family for, by
+        an astropy-backed adapter. See `_ginga_dist_for_stretch`.
+
         Parameters
         ----------
-        image_label : str or None
-            Label whose stored stretch to apply. A no-op unless the label
-            refers to the displayed image.
+        image_label : str
+            Resolved label whose stored stretch to apply.
         """
-        if (self._viewer.get_image() is None
-                or not self._is_displayed_label(image_label)):
-            return
         stretch = self.get_stretch(image_label=image_label)
         rgbmap = self._viewer.get_rgbmap()
         # Inject a fully parametrized distribution; set_dist fires the rgbmap's
@@ -551,26 +473,27 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
     def set_colormap(self, map_name, image_label=None, **kwargs):
         # Ginga only logs (rather than raises) on an unknown colormap name,
         # which would leave the stored state disagreeing with the display, so
-        # validate the name up front.
+        # validate the name up front -- even for images that are not
+        # displayed, which the _apply_colormap hook would never see.
         if map_name not in ginga_cmap.get_names():
             raise ValueError(f'Colormap {map_name!r} is not a valid ginga '
                              'colormap name.')
         super().set_colormap(map_name, image_label=image_label, **kwargs)
-        self._apply_colormap_to_ginga(image_label)
 
-    def _apply_colormap_to_ginga(self, image_label):
+    def _apply_colormap(self, image_label):
         """
         Push the stored colormap for a label into the ginga viewer.
 
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed.
+
         Parameters
         ----------
-        image_label : str or None
-            Label whose stored colormap to apply. A no-op unless the label
-            refers to the displayed image and a colormap has been set.
+        image_label : str
+            Resolved label whose stored colormap to apply. A no-op if no
+            colormap has been set for the label.
         """
-        if (self._viewer.get_image() is None
-                or not self._is_displayed_label(image_label)):
-            return
         cmap_name = self.get_colormap(image_label=image_label)
         # The colormap defaults to None and is not set on load, so guard
         # against pushing a None into ginga's set_color_map.
@@ -578,37 +501,26 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
             self._viewer.set_color_map(cmap_name)
 
     # ------------------------------------------------------------------
-    # Catalog API
+    # Catalog rendering
     # ------------------------------------------------------------------
-    def load_catalog(self, table, **kwargs):
-        super().load_catalog(table, **kwargs)
-        catalog_label = kwargs.get("catalog_label", None)
-        self._draw_catalog(catalog_label)
+    def _remove_catalog_marks(self, catalog_label):
+        """
+        Remove a catalog's markers from the ginga canvas.
 
-    def set_catalog_style(self, catalog_label=None, shape="circle",
-                          color="red", size=5, **kwargs):
-        super().set_catalog_style(
-            catalog_label=catalog_label, shape=shape, color=color, size=size,
-            **kwargs
-        )
-        self._draw_catalog(catalog_label)
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; ``remove_catalog``
+        calls it once per removed catalog (after expanding ``"*"``).
 
-    def remove_catalog(self, catalog_label=None, **kwargs):
-        # Figure out which canvas tags to remove before the bookkeeping in
-        # super() forgets about them.
-        if catalog_label == "*":
-            tags = [str(label) for label in self._catalogs]
-        else:
-            tags = [str(self._resolve_catalog_label(catalog_label))]
-
-        super().remove_catalog(catalog_label, **kwargs)
-
-        for tag in tags:
-            try:
-                self._viewer.canvas.delete_object_by_tag(tag)
-            except Exception:
-                # Nothing was drawn under this tag; that is fine.
-                pass
+        Parameters
+        ----------
+        catalog_label : str
+            Resolved label of the catalog whose markers to remove.
+        """
+        try:
+            self._viewer.canvas.delete_object_by_tag(str(catalog_label))
+        except Exception:
+            # Nothing was drawn under this tag; that is fine.
+            pass
 
     def _make_marker(self, style):
         """
@@ -647,14 +559,18 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         """
         Draw (or redraw) a catalog's markers on the ginga canvas.
 
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; called by
+        ``load_catalog`` and ``set_catalog_style``.
+
         Parameters
         ----------
-        catalog_label : str or None
-            Label of the catalog to draw. Its markers are drawn under a
-            canvas tag derived from the resolved label, replacing any
+        catalog_label : str
+            Resolved label of the catalog to draw. Its markers are drawn
+            under a canvas tag derived from the label, replacing any
             previous drawing for that catalog.
         """
-        tag = str(self._resolve_catalog_label(catalog_label))
+        tag = str(catalog_label)
 
         # Remove any existing drawing for this catalog before redrawing.
         try:
@@ -697,28 +613,20 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         """
         return self._viewer.get_window_size()[0]
 
-    def set_viewport(self, center=None, fov=None, image_label=None, **kwargs):
-        # The AIDA logic handles all of the WCS bookkeeping (and validation),
-        # which we need in case center/fov are in sky coordinates.
-        super().set_viewport(center=center, fov=fov, image_label=image_label,
-                             **kwargs)
-        self._apply_viewport_to_ginga(image_label)
-
-    def _apply_viewport_to_ginga(self, image_label):
+    def _apply_viewport(self, image_label):
         """
         Push the stored viewport (center + fov) into the ginga viewer as a
         pan position and scale.
 
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed.
+
         Parameters
         ----------
-        image_label : str or None
-            Label whose stored viewport to apply. A no-op unless the label
-            refers to the displayed image.
+        image_label : str
+            Resolved label whose stored viewport to apply.
         """
-        if (self._viewer.get_image() is None
-                or not self._is_displayed_label(image_label)):
-            return
-
         # Read the stored viewport back in pixel coordinates without going
         # through our own get_viewport (which would try to sync ginga state).
         viewport = super().get_viewport(sky_or_pixel='pixel',
@@ -770,7 +678,7 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
 
         if (image_label not in self._images
                 or self._viewer.get_image() is None
-                or image_label != self._displayed_image_label):
+                or image_label not in self._displayed_image_labels):
             # Only the displayed image can have been interactively panned or
             # zoomed; the live ginga state belongs to it alone.
             return

--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -23,7 +23,10 @@ from ginga.canvas.CanvasObject import drawCatalog
 from ginga.web.jupyterw.ImageViewJpw import EnhancedCanvasView
 from ginga.util.wcs import ra_deg_to_str, dec_deg_to_str
 
-from astro_image_display_api import ImageViewerLogic, docs_from_super_if_missing
+from astro_image_display_api.image_viewer_logic import (
+    ImageViewerLogic,
+    docs_from_image_viewer_logic_if_missing,
+)
 
 __all__ = ['ImageWidget']
 
@@ -160,7 +163,7 @@ def _ginga_dist_for_stretch(stretch, hashsize):
 
 
 # The inheritance order below matters -- VBox needs to come first
-@docs_from_super_if_missing
+@docs_from_image_viewer_logic_if_missing
 class ImageWidget(ipyw.VBox, ImageViewerLogic):
     """
     Image widget for Jupyter notebook using the Ginga viewer.
@@ -202,6 +205,13 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         ImageViewerLogic.__post_init__(self)
 
         self._viewer = EnhancedCanvasView(logger=logger)
+
+        # A field of view smaller than one data pixel is a legitimate request
+        # (e.g. an angular fov much finer than the image's pixel scale). By
+        # default ginga refuses the corresponding scale, which would leave the
+        # viewer silently out of sync with the viewport stored by the AIDA
+        # logic layer.
+        self._viewer.settings.set(sanity_check_scale=False)
 
         self._jup_img = ipyw.Image(format='jpeg')
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -132,7 +132,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
@@ -148,6 +147,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/d3/642a6dc3db8ea558a9b5fbc83815b197861868dc98f98a789b85c7660670/ipyevents-2.0.4-py3-none-any.whl
@@ -288,7 +288,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
@@ -308,6 +307,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
@@ -442,7 +442,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
@@ -461,6 +460,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
@@ -591,7 +591,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl
@@ -607,6 +606,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b4/11/97233cf23ad5411ac6f13b1d6ee3888f90ace4f974d9bf9db887aa428912/pyerfa-2.0.1.5-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
@@ -778,7 +778,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
@@ -796,6 +795,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/dd/d95843947392524418aa9fc4e8d205e82b4261ab2d2fab4abce7a14ee7c0/sphinx_gallery-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/a4/66c1fd4f8fab88faf71cee04a945f9806ba0fef753f2cfc8be6353f64508/sphinxext_opengraph-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
@@ -965,7 +965,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
@@ -987,6 +986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/dd/d95843947392524418aa9fc4e8d205e82b4261ab2d2fab4abce7a14ee7c0/sphinx_gallery-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/a4/66c1fd4f8fab88faf71cee04a945f9806ba0fef753f2cfc8be6353f64508/sphinxext_opengraph-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
@@ -1150,7 +1150,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
@@ -1171,6 +1170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/dd/d95843947392524418aa9fc4e8d205e82b4261ab2d2fab4abce7a14ee7c0/sphinx_gallery-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
@@ -1329,7 +1329,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl
@@ -1347,6 +1346,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b4/11/97233cf23ad5411ac6f13b1d6ee3888f90ace4f974d9bf9db887aa428912/pyerfa-2.0.1.5-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/dd/d95843947392524418aa9fc4e8d205e82b4261ab2d2fab4abce7a14ee7c0/sphinx_gallery-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/a4/66c1fd4f8fab88faf71cee04a945f9806ba0fef753f2cfc8be6353f64508/sphinxext_opengraph-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
@@ -1519,7 +1519,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
@@ -1535,6 +1534,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/d3/642a6dc3db8ea558a9b5fbc83815b197861868dc98f98a789b85c7660670/ipyevents-2.0.4-py3-none-any.whl
@@ -1695,7 +1695,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
@@ -1715,6 +1714,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
@@ -1869,7 +1869,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
@@ -1888,6 +1887,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
@@ -2037,7 +2037,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/c0/fdf9d3ee103ce66a55f0532835ad5e154226c5222423c6636ba049dc42fc/traittypes-0.2.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl
@@ -2053,6 +2052,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b4/11/97233cf23ad5411ac6f13b1d6ee3888f90ace4f974d9bf9db887aa428912/pyerfa-2.0.1.5-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
@@ -4706,7 +4706,7 @@ packages:
   name: astrowidgets
   requires_dist:
   - astropy
-  - astro-image-display-api>=0.2.1
+  - astro-image-display-api>=0.3.0
   - ginga>=3.4
   - pillow
   - ipywidgets>=8
@@ -6410,24 +6410,6 @@ packages:
   sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
   requires_dist:
   - pytest ; extra == 'tests'
-- pypi: https://files.pythonhosted.org/packages/91/46/fb09d658aef2a726a9aeaeda6a12690ed45cd077ab86f194c194a3ee5723/astro_image_display_api-0.2.1-py3-none-any.whl
-  name: astro-image-display-api
-  version: 0.2.1
-  sha256: 1967c2e93370fd6ee80ff0a9c7844b39c8778e6c2174daf6bb0939bf8a2c4e0b
-  requires_dist:
-  - astropy
-  - numpy
-  - graphviz ; extra == 'docs'
-  - pytest ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-astropy[confv2] ; extra == 'docs'
-  - sphinx-design ; extra == 'docs'
-  - black ; extra == 'test'
-  - pre-commit ; extra == 'test'
-  - pytest-astropy ; extra == 'test'
-  - ruff ; extra == 'test'
-  - tox ; extra == 'test'
-  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl
   name: tornado
   version: 6.5.7
@@ -6918,6 +6900,25 @@ packages:
   version: 1.17.0
   sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/b8/3e/58c46c8c3048799ae9d61677a3f8c6ebf3237531c06001fc92abdae3ecbe/astro_image_display_api-0.3.0-py3-none-any.whl
+  name: astro-image-display-api
+  version: 0.3.0
+  sha256: 7da9f708b6b7ae9d84db1c6022a2385a71ad4ccc3fdf62d7a6d1d14f246e4665
+  requires_dist:
+  - astropy
+  - numpy
+  - graphviz ; extra == 'docs'
+  - pytest ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-astropy[confv2] ; extra == 'docs'
+  - sphinx-design ; extra == 'docs'
+  - black ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest-astropy ; extra == 'test'
+  - ruff ; extra == 'test'
+  - tox ; extra == 'test'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/b8/dd/d95843947392524418aa9fc4e8d205e82b4261ab2d2fab4abce7a14ee7c0/sphinx_gallery-0.21.0-py3-none-any.whl
   name: sphinx-gallery
   version: 0.21.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy",
-    "astro-image-display-api>=0.2.1",
+    "astro-image-display-api>=0.3.0",
     "ginga>=3.4",
     "pillow",
     "ipywidgets>=8",


### PR DESCRIPTION
This slims the ginga backend down to the rendering-hook interface added to `ImageViewerLogic` in astro-image-display-api 0.3.0 (the template-method refactor).

Now that #205 has merged, this branch has been rebased onto `main` and contains only this PR's commits. The dependency pin in `pyproject.toml` is bumped to `astro-image-display-api>=0.3.0` (released), and `pixi.lock` is updated to match.

**Expected CI failures:** the bqplot test jobs fail because the bqplot backend has not yet been adapted to AIDA 0.3.0 — that is #215. The ginga suite (`test_widget_api_ginga.py`, 110 tests) passes in full. `main` shows the same bqplot failures in the jobs that install the released AIDA (its pixi jobs stay green only because the lockfile there still pins AIDA 0.2.x).

### What changed

- Deleted the public-method wrappers (`load_image`, `set_cuts`, `set_stretch`, `set_viewport`, `load_catalog`, `set_catalog_style`, `remove_catalog`). The AIDA templates now own state handling and label resolution and call the backend's rendering hooks with already-resolved labels, gated on the displayed image.
- The ginga display glue now lives in the hooks: `_render_image`, `_apply_cuts`, `_apply_stretch`, `_apply_colormap`, `_apply_viewport`, `_draw_catalog`, `_remove_catalog_marks`. The hooks no longer do their own displayed-label gating or label resolution.
- Deleted the local displayed-label tracking (`_displayed_image_label` / `_is_displayed_label`) in favor of upstream `_displayed_image_labels`, and the local docs decorator in favor of `docs_from_image_viewer_logic_if_missing` imported from `astro_image_display_api.image_viewer_logic`.
- Kept a thin `set_colormap` override that validates the colormap name against ginga's list, so a bad name still raises `ValueError` even when the target image is not displayed (the hook would never see that case).
- Disabled ginga's `sanity_check_scale` so a sub-pixel field of view (which the AIDA 0.3.0 test suite requests after its sky-to-pixel fov fix) is honored instead of silently refused.
- Interactive marking/cursor API is untouched.

Generated by Claude Code at Matt Craig's direction.
