### PR TITLE
Slim the bqplot backend to AIDA rendering hooks

### DIFF
--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -555,10 +555,6 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         finally:
             self._refresh_deferred = False
 
-    @property
-    def viewer(self):
-        return self._astro_im
-
     # ------------------------------------------------------------------
     # Rendering hooks
     #

--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -15,7 +15,10 @@ import ipywidgets as ipw
 from matplotlib import pyplot
 from matplotlib.colors import to_hex
 
-from astro_image_display_api import ImageViewerLogic, docs_from_super_if_missing
+from astro_image_display_api.image_viewer_logic import (
+    ImageViewerLogic,
+    docs_from_image_viewer_logic_if_missing,
+)
 
 
 class _AstroImage(ipw.VBox):
@@ -350,7 +353,7 @@ def bqcolors(colormap, reverse=False):
 
 
 # The inheritance order below matters -- VBox needs to come first
-@docs_from_super_if_missing
+@docs_from_image_viewer_logic_if_missing
 class ImageWidget(ipw.VBox, ImageViewerLogic):
     def __init__(self, *args, display_width=500, display_aspect_ratio=1):
         super().__init__(*args)

--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 
 import numpy as np
@@ -15,34 +15,7 @@ import ipywidgets as ipw
 from matplotlib import pyplot
 from matplotlib.colors import to_hex
 
-from astro_image_display_api.image_viewer_logic import ImageViewerLogic
-
-
-def docs_from_super_if_missing(cls):
-    """
-    Decorator to copy the docstrings from the interface methods to the
-    methods in the class.
-    """
-    for name, method in cls.__dict__.items():
-        if not name.startswith("_"):
-            if method.__doc__:
-                continue
-            # Not sure why this fails, but it does.
-            # method.__doc__ = inspect.getdoc(method)
-            interface_method = getattr(ImageViewerLogic, name, None)
-
-            if interface_method:
-                method.__doc__ = interface_method.__doc__
-            # print(f"{method} {method.__doc__} {inspect.getdoc(method)} {interface_method.__doc__=}")
-            # supers = cls.__mro__
-            # for a_super in supers:
-            #     print(f"{name=} {a_super=}")
-            #     interface_method = getattr(a_super, name, None)
-            #     if interface_method:
-            #         print(f"{name=} {a_super=}")
-            #         method.__doc__ = interface_method.__doc__
-            #         break
-    return cls
+from astro_image_display_api import ImageViewerLogic, docs_from_super_if_missing
 
 
 class _AstroImage(ipw.VBox):
@@ -381,9 +354,9 @@ def bqcolors(colormap, reverse=False):
 class ImageWidget(ipw.VBox, ImageViewerLogic):
     def __init__(self, *args, display_width=500, display_aspect_ratio=1):
         super().__init__(*args)
-        self._set_up_catalog_image_dicts()
-        # self.image_width = image_width
-        # self.image_height = image_height
+        # ImageViewerLogic is a dataclass; we do not run its __init__, so run
+        # the post-init hook it would otherwise provide to set up its state.
+        ImageViewerLogic.__post_init__(self)
 
         self._astro_im = _AstroImage(display_width=display_width,
                                      viewer_aspect_ratio=display_aspect_ratio)
@@ -392,10 +365,12 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         self._default_cuts = apviz.AsymmetricPercentileInterval(30, 96)
         self._default_stretch = None
         self._default_colormap = 'Greys_r'
-        # Store the default through the API layer (which keeps settings
-        # for the None label even before a load) so that get_colormap
-        # reports it; set_colormap also applies it to the front end.
-        self.set_colormap(self._default_colormap)
+        # The API layer stores settings per image, so nothing can be stored
+        # before a load; apply the default colormap directly to the front
+        # end so the empty viewer already shows it. When the first image is
+        # loaded, _render_image stores the widget defaults for it so that
+        # the get_* methods report what is displayed.
+        self._astro_im.set_color(bqcolors(self._default_colormap))
 
         self._data = None
         self._wcs = None
@@ -491,13 +466,17 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
             Watch for changes in the viewport (pan or zoom) from the viewer.
             """
             new_width = self._astro_im.get_current_width()
-            if new_width is None or self._updating_viewport:
+            if (new_width is None or self._updating_viewport
+                    or not self._displayed_image_labels):
                 # There is no image yet, or this object is in the process
                 # of changing the viewport, so return
                 return
 
+            # A pan or zoom in the GUI is always a change to the view of
+            # the displayed image.
+            image_label = self._displayed_image_labels[0]
             current = self.get_viewport(sky_or_pixel='pixel',
-                                        image_label=self._current_image_label)
+                                        image_label=image_label)
             old_width = current["fov"]
             old_center = current["center"]
             new_center = self._astro_im.center
@@ -514,7 +493,8 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
                 # Let the viewport handler know the GUI itself generated this
                 # change, which means the GUI does not need to be updated.
                 self._viewport_change_source_is_gui = True
-                self.set_viewport(center=new_center, fov=new_width)
+                self.set_viewport(center=new_center, fov=new_width,
+                                  image_label=image_label)
 
         # Observe changes to the maximum of both the x and y scales so that
         # horizontal pan, vertical pan, and zoom are all detected. Observing
@@ -546,17 +526,18 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
             self._astro_im.set_data(self._interval_and_stretch(stretch=stretch, cuts=cuts),
                                     reset_view=reset_view)
 
-    def _refresh_display(self, image_label=None, reset_view=False):
+    def _refresh_display(self, image_label=None):
         """
         Recompute the displayed array from the cuts and stretch stored
-        for the image and send it to the viewer.
+        for the image and send it to the viewer. The viewport (zoom/pan)
+        is left untouched; it is owned by the ``_apply_viewport`` hook.
         """
         if self._data is None or self._refresh_deferred:
             return
 
         self._send_data(cuts=self.get_cuts(image_label=image_label),
                         stretch=self.get_stretch(image_label=image_label),
-                        reset_view=reset_view)
+                        reset_view=False)
 
     @contextmanager
     def _defer_refresh(self):
@@ -572,78 +553,211 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
             self._refresh_deferred = False
 
     @property
-    def _current_image_label(self):
-        """
-        Image label for the most recently loaded image
-        """
-        return list(self._images.keys())[-1]
-
-    def set_stretch(self, value, image_label=None, **kwargs):
-        super().set_stretch(value, image_label=image_label, **kwargs)
-        # Changing the stretch only affects the color mapping, so leave the
-        # current viewport (zoom/pan) untouched.
-        self._refresh_display(image_label=image_label)
-
-    def set_cuts(self, value, image_label=None, **kwargs):
-        super().set_cuts(value, image_label=image_label, **kwargs)
-        # Changing the cuts only affects the color mapping, so leave the
-        # current viewport (zoom/pan) untouched.
-        self._refresh_display(image_label=image_label)
-
-    @property
     def viewer(self):
         return self._astro_im
 
-    # The methods, grouped loosely by purpose
-    def load_image(self, image, image_label=None, **kwargs):
-        # A newly loaded image is always displayed with the current cuts,
-        # stretch and colormap; only the viewport resets. Capture the
-        # current settings before the API layer replaces them with its own
-        # defaults during the load.
-        if image_label is not None and image_label in self._images:
-            # Re-loading an existing image: its own settings are current.
-            settings_label = image_label
-            have_current = True
-        elif self._data is not None:
-            # A new image: carry forward from the displayed image. Its label
-            # is legitimately None when the caller never passed one, so guard
-            # on whether an image is displayed, not on the label's value.
-            settings_label = self._current_image_label
-            have_current = True
-        else:
-            # Nothing has been displayed yet.
-            have_current = False
+    # ------------------------------------------------------------------
+    # Rendering hooks
+    #
+    # The public API methods inherited from ImageViewerLogic are templates
+    # that own all state handling and label resolution, then call these
+    # hooks with already-resolved labels to push the stored state into the
+    # bqplot figure. The _apply_* hooks are only called for the displayed
+    # image.
+    # ------------------------------------------------------------------
+    @contextmanager
+    def _batch_update(self):
+        """
+        Batch the front-end updates of a group of state changes.
 
-        if have_current:
-            current_cuts = self.get_cuts(image_label=settings_label)
-            current_stretch = self.get_stretch(image_label=settings_label)
-            current_colormap = self.get_colormap(image_label=settings_label)
-        else:
-            current_cuts = self._default_cuts
-            # Leave the stretch the API layer stores on load (linear).
-            current_stretch = self._default_stretch
-            current_colormap = self._default_colormap
+        Overrides the no-op hook from
+        `~astro_image_display_api.ImageViewerLogic`; ``load_image`` wraps
+        its state changes and rendering-hook calls in this context.
 
-        # Hold the sync so the scale changes from the viewport
-        # initialization in the API layer arrive at the front end in the
-        # same batch as the new image data, avoiding flicker from
-        # intermediate redraws.
-        with self._astro_im._hold_all_sync():
-            # Store the settings for the new image so the get_* methods
-            # report what is displayed. Defer the refresh each setter
-            # triggers; one refresh at the end displays the image.
-            with self._defer_refresh():
-                super().load_image(image, image_label=image_label, **kwargs)
+        The composition is: hold the front-end sync of the image mark and
+        the scales for the whole block (so each widget sends one state
+        message, with the image mark flushing first -- see
+        ``_AstroImage._hold_all_sync``), and defer the display refreshes
+        that the ``_apply_*`` hooks trigger, collapsing them into a single
+        recomputation of the displayed array that runs while the front-end
+        sync is still held.
+        """
+        with ExitStack() as stack:
+            # Entered first, so it releases last: everything below happens
+            # while the front-end sync is held.
+            stack.enter_context(self._astro_im._hold_all_sync())
+            # Runs on exit, after _defer_refresh has released: the one
+            # refresh that replaces the refreshes deferred in the block.
+            stack.callback(self._refresh_after_batch)
+            stack.enter_context(self._defer_refresh())
+            yield
 
-                self.set_cuts(current_cuts, image_label=image_label)
-                if current_stretch is not None:
-                    self.set_stretch(current_stretch, image_label=image_label)
-                self.set_colormap(current_colormap, image_label=image_label)
+    def _refresh_after_batch(self):
+        """
+        Recompute and send the displayed array once after a batched update.
 
-                data = self.get_image(image_label=image_label)
-                self._data = data.data if isinstance(data, NDData) else data
+        The viewport is not touched here: the ``_apply_viewport`` hook has
+        already pushed the stored viewport into the scales during the batch.
+        """
+        for image_label in self._displayed_image_labels:
+            self._refresh_display(image_label=image_label)
 
-            self._refresh_display(image_label=image_label, reset_view=True)
+    def _render_image(self, image_label):
+        """
+        Make the image stored under a label the one the widget displays.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`. ``load_image`` calls it
+        after storing the image data and settings; the ``_apply_*`` hooks
+        are called afterwards to push the stored settings into the display.
+
+        Parameters
+        ----------
+        image_label : str
+            Resolved label of the image to display.
+        """
+        info = self._images[image_label]
+
+        if info.colormap is None:
+            # load_image carries the displayed image's cuts, stretch and
+            # colormap forward to the new image, and any image that has been
+            # displayed has a colormap (this very block guarantees it), so a
+            # missing colormap means nothing was carried forward: this image
+            # is the first to be displayed. Store the widget's defaults for
+            # it so that the get_* methods report what is displayed.
+            info.colormap = self._default_colormap
+            info.cuts = self._default_cuts
+            if self._default_stretch is not None:
+                info.stretch = self._default_stretch
+
+        data = info.data
+        self._data = data.data if isinstance(data, NDData) else data
+        self._wcs = info.wcs
+
+    def _apply_cuts(self, image_label):
+        """
+        Re-display the image using the cut levels stored for a label.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed. Changing the cuts only affects the color
+        mapping, so the current viewport (zoom/pan) is left untouched.
+
+        Parameters
+        ----------
+        image_label : str
+            Resolved label whose stored cuts to apply.
+        """
+        self._refresh_display(image_label=image_label)
+
+    def _apply_stretch(self, image_label):
+        """
+        Re-display the image using the stretch stored for a label.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed. Changing the stretch only affects the color
+        mapping, so the current viewport (zoom/pan) is left untouched.
+
+        Parameters
+        ----------
+        image_label : str
+            Resolved label whose stored stretch to apply.
+        """
+        self._refresh_display(image_label=image_label)
+
+    def _apply_colormap(self, image_label):
+        """
+        Push the colormap stored for a label into the bqplot color scale.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed.
+
+        Parameters
+        ----------
+        image_label : str
+            Resolved label whose stored colormap to apply.
+        """
+        self._astro_im.set_color(
+            bqcolors(self.get_colormap(image_label=image_label)))
+
+    def _apply_viewport(self, image_label):
+        """
+        Push the viewport stored for a label into the bqplot scales.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; only called when the
+        label is displayed.
+
+        Parameters
+        ----------
+        image_label : str
+            Resolved label whose stored viewport (center and field of view)
+            to apply.
+        """
+        if self._viewport_change_source_is_gui:
+            # The GUI itself (a pan or zoom in the browser) generated this
+            # viewport change, so the front end is already up to date.
+            self._viewport_change_source_is_gui = False
+            return
+
+        # Get the viewport in pixel coordinates; the API layer handles all
+        # of the WCS stuff in the event the stored fov is in sky units.
+        viewport = self.get_viewport(image_label=image_label,
+                                     sky_or_pixel='pixel')
+
+        # Suppress the handling of the scale changes made below as if they
+        # were a pan or zoom from the GUI.
+        self._updating_viewport = True
+        try:
+            self._astro_im.center = viewport['center']
+            self._astro_im.set_size(viewport['fov'], direction='x')
+        finally:
+            self._updating_viewport = False
+
+    def _draw_catalog(self, catalog_label):
+        """
+        Draw (or redraw) a catalog's markers as a bqplot scatter mark.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; called by
+        ``load_catalog`` and ``set_catalog_style``.
+
+        Parameters
+        ----------
+        catalog_label : str
+            Resolved label of the catalog to draw. Its markers are drawn
+            under a mark id equal to the label, replacing any previous
+            scatter mark for that catalog.
+        """
+        catalog = self.get_catalog(catalog_label=catalog_label)
+        style = self.get_catalog_style(catalog_label=catalog_label)
+
+        self._astro_im.plot_named_markers(
+            catalog["x"],
+            catalog["y"],
+            catalog_label,
+            color=style.get("color", "red"),
+            # bqplot expects the size in pixels squared
+            size=style.get("size", 5)**2,
+            shape=style.get("shape", "circle"),
+        )
+
+    def _remove_catalog_marks(self, catalog_label):
+        """
+        Remove a catalog's scatter mark from the bqplot figure.
+
+        Overrides the no-op rendering hook from
+        `~astro_image_display_api.ImageViewerLogic`; ``remove_catalog``
+        calls it once per removed catalog (after expanding ``"*"``).
+
+        Parameters
+        ----------
+        catalog_label : str
+            Resolved label of the catalog whose markers to remove.
+        """
+        self._astro_im.remove_named_markers(catalog_label)
 
     # Saving contents of the view and accessing the view
     def save(self, filename, overwrite=False, **kwargs):
@@ -659,83 +773,6 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         else:
             raise ValueError('Saving is not supported for that'
                              'file type. Use .png or .svg')
-
-    def set_colormap(self, cmap_name, image_label=None, **kwargs):
-        super().set_colormap(cmap_name, image_label=image_label, **kwargs)
-        self._astro_im.set_color(bqcolors(cmap_name, reverse=False))
-
-    def load_catalog(
-        self,
-        table,
-        **kwargs
-    ):
-        super().load_catalog(table, **kwargs)
-        catalog_label = kwargs.get("catalog_label", None)
-        self.set_catalog_style(
-            **self.get_catalog_style(catalog_label=catalog_label)
-        )
-
-    def set_catalog_style(
-            self,
-            catalog_label=None,
-            shape="circle",
-            color="red",
-            size=5,
-            **kwargs
-    ):
-        super().set_catalog_style(
-            catalog_label=catalog_label,
-            shape=shape,
-            color=color,
-            size=size,
-            **kwargs
-        )
-        this_catalog = self.get_catalog(catalog_label=catalog_label)
-
-        self._astro_im.plot_named_markers(
-            this_catalog["x"],
-            this_catalog["y"],
-            str(catalog_label),
-            color=color,
-            size=size**2,  # bqplot expects size in pixels squared
-            shape=shape,
-        )
-
-    def remove_catalog(self, catalog_label=None, **kwargs):
-        super().remove_catalog(catalog_label, **kwargs)
-        if catalog_label == "*":
-            # Remove all catalogs
-            self._astro_im.remove_markers()
-        else:
-            self._astro_im.remove_named_markers(str(catalog_label))
-
-    def set_viewport(self, center=None, fov=None, image_label=None, **kwargs):
-        # This will handle all of the WCS stuff, which we need in the event
-        # the fov is in sky coordinates.
-        super().set_viewport(center=center, fov=fov, image_label=image_label, **kwargs)
-
-        # Get the viewport in pixel coordinates
-        viewport = self.get_viewport(image_label=image_label, sky_or_pixel='pixel')
-        if not self._viewport_change_source_is_gui:
-            # This is used in the viewport handler to suppress
-            # handling during a programmatic change to the
-            # viewport.
-            self._updating_viewport = True
-            # Set the center of the image to the center of the viewport
-            # Note the coordinates are reversed because that is how it goes
-            # with image display vs array indices.
-            self._astro_im.center = viewport['center']
-
-            # Set the size of the image to the size of the viewport
-            self._astro_im.set_size(viewport['fov'], direction='x')
-            self._updating_viewport = False
-        else:
-            # The GUI is the source of the change, so do not update the
-            # image center or size.
-            self._viewport_change_source_is_gui = False
-
-    def get_viewport(self, sky_or_pixel=None, image_label=None, **kwargs):
-        return super().get_viewport(sky_or_pixel, image_label, **kwargs)
 
     @property
     def print_out(self):

--- a/astrowidgets/tests/test_widget_api_bqplot.py
+++ b/astrowidgets/tests/test_widget_api_bqplot.py
@@ -91,9 +91,9 @@ def test_catalog_marks_use_resolved_label():
     assert image._astro_im._scatter_marks == {}
 
 
-def test_catalog_generated_label_targets_marks():
-    # A catalog loaded without a label gets a generated label; styling or
-    # removing it by that generated label must target its marks.
+def test_catalog_default_label_targets_marks():
+    # A catalog loaded without a label goes under the shared default
+    # label; styling or removing it by that label must target its marks.
     image = ImageWidget()
     image.load_catalog(Table({'x': [1.0], 'y': [2.0]}))
 
@@ -231,9 +231,9 @@ class TestBQplotWidget(ImageAPITest):
     def test_load_image_keeps_settings_without_labels(self):
         # The carry-forward of cuts, stretch and colormap must work in the
         # common interactive case where no image_label is ever passed, so
-        # every image gets a generated label. Loading a second image must
-        # display it with the settings currently in effect, not fall back
-        # to the widget defaults.
+        # every load targets the shared default label. Loading a second
+        # image must display it with the settings currently in effect, not
+        # fall back to the widget defaults.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
@@ -250,8 +250,8 @@ class TestBQplotWidget(ImageAPITest):
         arr2[10, 15] = 65535
         self.image.load_image(arr2)
 
-        # Both images stay loaded under generated labels, so the get_*
-        # methods need a label; ask about the displayed (new) image.
+        # The second load replaced the first under the shared default
+        # label, keeping the settings attached to that label.
         displayed_label = self.image._displayed_image_labels[0]
         assert self.image.get_cuts(image_label=displayed_label) is cuts
         assert self.image.get_stretch(image_label=displayed_label) is stretch
@@ -261,11 +261,13 @@ class TestBQplotWidget(ImageAPITest):
         displayed = np.asarray(self.image._astro_im._image.image)
         np.testing.assert_allclose(displayed, stretch(cuts(arr2)))
 
-    def test_load_image_without_label_never_replaces(self):
-        # An unlabeled load gets a generated label, so it can never
-        # silently replace a previously loaded image: the labeled image
-        # keeps its data and settings, while the new image takes over the
-        # display with the widget's default settings.
+    def test_load_image_without_label_targets_default_label(self):
+        # An unlabeled load resolves to the shared default label, so it
+        # never silently replaces an explicitly labeled image: the labeled
+        # image keeps its data and settings, while the new image takes
+        # over the display with the widget's default settings. Repeated
+        # unlabeled loads, though, replace each other under that one
+        # default label.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
@@ -281,7 +283,7 @@ class TestBQplotWidget(ImageAPITest):
             np.asarray(self.image.get_image(image_label='labeled')), arr)
         assert self.image.get_cuts(image_label='labeled') is labeled_cuts
 
-        # ...and the new image is displayed, under a generated label, with
+        # ...and the new image is displayed, under the default label, with
         # the widget's default cuts rather than the labeled image's.
         new_label = self.image._displayed_image_labels[0]
         assert new_label != 'labeled'
@@ -292,6 +294,14 @@ class TestBQplotWidget(ImageAPITest):
         assert isinstance(new_cuts, apviz.AsymmetricPercentileInterval)
         assert new_cuts.lower_percentile == 30
         assert new_cuts.upper_percentile == 96
+
+        # A further unlabeled load replaces the previous unlabeled image
+        # in place: same label, new data, no third image.
+        self.image.load_image(arr + 5)
+        assert self.image._displayed_image_labels[0] == new_label
+        np.testing.assert_array_equal(
+            np.asarray(self.image.get_image(image_label=new_label)), arr + 5)
+        assert sorted(self.image.image_labels) == sorted(('labeled', new_label))
 
     def test_first_load_stores_widget_default_cuts(self):
         # With nothing loaded yet there are no current settings to carry

--- a/astrowidgets/tests/test_widget_api_bqplot.py
+++ b/astrowidgets/tests/test_widget_api_bqplot.py
@@ -8,9 +8,9 @@ from traitlets import TraitError
 from astro_image_display_api.api_test import ImageAPITest
 from astro_image_display_api import ImageViewerInterface
 
-bqplot = pytest.importorskip(
-    "bqplot", reason="Package required for test is not " "available."
-)
+bqplot = pytest.importorskip("bqplot",
+                             reason="Package required for test is not "
+                                    "available.")
 from astrowidgets.bqplot import ImageWidget, bqcolors  # noqa: E402
 
 
@@ -27,7 +27,7 @@ def test_mouse_click_does_not_raise_or_block_callbacks():
     image = ImageWidget()
 
     # A click before any image is loaded should be a no-op.
-    image._mouse_click({"domain": {"x": 3, "y": 3}})
+    image._mouse_click({'domain': {'x': 3, 'y': 3}})
 
     image.load_image(np.zeros((10, 10)))
 
@@ -40,7 +40,7 @@ def test_mouse_click_does_not_raise_or_block_callbacks():
 
     # Simulate the comm message a real mouse click produces; this invokes
     # all registered on_msg callbacks in order, built-in handler first.
-    click_event = {"event": "click", "domain": {"x": 3, "y": 3}}
+    click_event = {'event': 'click', 'domain': {'x': 3, 'y': 3}}
     image._astro_im.interaction._handle_custom_msg(click_event, [])
 
     assert calls == [click_event]
@@ -63,7 +63,9 @@ def test_catalog_markers_use_scatter_shape_size_and_arrays(shape):
     np.testing.assert_array_equal(marker.x, [1.0])
     np.testing.assert_array_equal(marker.y, [2.0])
 
-    image.set_catalog_style(catalog_label="test", size=7, shape=shape)
+    image.set_catalog_style(
+        catalog_label="test", size=7, shape=shape
+    )
 
     marker = image._astro_im._scatter_marks["test"]
     assert type(marker) is bqplot.Scatter
@@ -71,21 +73,52 @@ def test_catalog_markers_use_scatter_shape_size_and_arrays(shape):
     assert marker.marker == shape
 
 
+def test_catalog_marks_use_resolved_label():
+    # Regression test for #213: set_catalog_style and remove_catalog used
+    # the caller's (unresolved) catalog_label as the bqplot mark id, so an
+    # unlabeled set_catalog_style call plotted an orphan second scatter
+    # under the id "None" and an unlabeled remove_catalog raised. The
+    # resolved label must always be the mark id.
+    image = ImageWidget()
+    image.load_catalog(Table({'x': [1.0], 'y': [2.0]}), catalog_label='test')
+    assert list(image._astro_im._scatter_marks) == ['test']
+
+    image.set_catalog_style(size=7)
+    assert list(image._astro_im._scatter_marks) == ['test']
+    assert image._astro_im._scatter_marks['test'].default_size == 49
+
+    image.remove_catalog()
+    assert image._astro_im._scatter_marks == {}
+
+
+def test_catalog_generated_label_targets_marks():
+    # A catalog loaded without a label gets a generated label; styling or
+    # removing it by that generated label must target its marks.
+    image = ImageWidget()
+    image.load_catalog(Table({'x': [1.0], 'y': [2.0]}))
+
+    label = image.catalog_labels[0]
+    assert list(image._astro_im._scatter_marks) == [label]
+
+    image.set_catalog_style(catalog_label=label, size=7)
+    assert list(image._astro_im._scatter_marks) == [label]
+    assert image._astro_im._scatter_marks[label].default_size == 49
+
+    image.remove_catalog(catalog_label=label)
+    assert image._astro_im._scatter_marks == {}
+
+
 class TestBQplotWidget(ImageAPITest):
     image_widget_class = ImageWidget
     cursor_error_classes = (ValueError, TraitError)
 
-    @pytest.mark.skip(
-        reason="Saving is done in javascript and requires "
-        "a running browser."
-    )
+    @pytest.mark.skip(reason="Saving is done in javascript and requires "
+                             "a running browser.")
     def test_save(self, tmp_path):
         pass
 
-    @pytest.mark.skip(
-        reason="Saving is done in javascript and requires "
-        "a running browser."
-    )
+    @pytest.mark.skip(reason="Saving is done in javascript and requires "
+                             "a running browser.")
     def test_save_overwrite(self, tmp_path):
         pass
 
@@ -114,22 +147,19 @@ class TestBQplotWidget(ImageAPITest):
 
         self.image._data = arr
         expected = apviz.AsymmetricPercentileInterval(30, 96)(arr)
-        np.testing.assert_allclose(
-            self.image._interval_and_stretch(), expected
-        )
+        np.testing.assert_allclose(self.image._interval_and_stretch(), expected)
 
     def test_default_colormap_is_greys_r(self, data):
         # With no colormap explicitly set, the display should use Greys_r
         # (low = black, high = white), the usual astronomical convention,
-        # both before and after an image is loaded, and get_colormap should
-        # report it.
-        greys_r = bqcolors("Greys_r")
-        assert self.image._astro_im._image.scales["image"].colors == greys_r
-        assert self.image.get_colormap() == "Greys_r"
+        # both before and after an image is loaded. Settings are stored per
+        # image, so get_colormap can only report it once an image is loaded.
+        greys_r = bqcolors('Greys_r')
+        assert self.image._astro_im._image.scales['image'].colors == greys_r
 
         self.image.load_image(data)
-        assert self.image.get_colormap() == "Greys_r"
-        assert self.image._astro_im._image.scales["image"].colors == greys_r
+        assert self.image.get_colormap() == 'Greys_r'
+        assert self.image._astro_im._image.scales['image'].colors == greys_r
 
     def test_load_image_keeps_current_display_settings(self):
         # Loading a new image should display it with the cuts, stretch and
@@ -141,69 +171,62 @@ class TestBQplotWidget(ImageAPITest):
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
 
-        self.image.load_image(arr, image_label="first")
+        self.image.load_image(arr, image_label='first')
         cuts = apviz.AsymmetricPercentileInterval(5, 90)
         stretch = apviz.LogStretch()
-        self.image.set_cuts(cuts, image_label="first")
-        self.image.set_stretch(stretch, image_label="first")
-        self.image.set_colormap("viridis", image_label="first")
+        self.image.set_cuts(cuts, image_label='first')
+        self.image.set_stretch(stretch, image_label='first')
+        self.image.set_colormap('viridis', image_label='first')
 
-        self.image.load_image(arr, image_label="second")
+        self.image.load_image(arr, image_label='second')
 
-        assert self.image.get_cuts(image_label="second") is cuts
-        assert self.image.get_stretch(image_label="second") is stretch
-        assert self.image.get_colormap(image_label="second") == "viridis"
-        assert self.image._astro_im._image.scales["image"].colors == bqcolors(
-            "viridis"
-        )
+        assert self.image.get_cuts(image_label='second') is cuts
+        assert self.image.get_stretch(image_label='second') is stretch
+        assert self.image.get_colormap(image_label='second') == 'viridis'
+        assert self.image._astro_im._image.scales['image'].colors == bqcolors('viridis')
 
         displayed = np.asarray(self.image._astro_im._image.image)
         np.testing.assert_allclose(displayed, stretch(cuts(arr)))
 
-    def test_reload_existing_label_keeps_its_settings(self):
-        # When new data is loaded under an existing image label, that
-        # label's own stored settings are the current ones for the image
-        # and must be kept, even if a different image was loaded (and so
-        # displayed) more recently.
+    def test_reload_existing_label_carries_displayed_settings(self):
+        # Loading data under an existing image label follows the same
+        # carry-forward rule as any other load: the settings of the image
+        # being replaced on the display -- not the reloaded label's old
+        # settings -- are carried to the new image and shown.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
 
-        first_cuts = apviz.AsymmetricPercentileInterval(5, 90)
-        first_stretch = apviz.LogStretch()
-        self.image.load_image(arr, image_label="first")
-        self.image.set_cuts(first_cuts, image_label="first")
-        self.image.set_stretch(first_stretch, image_label="first")
-        self.image.set_colormap("viridis", image_label="first")
+        self.image.load_image(arr, image_label='first')
+        self.image.set_cuts(apviz.AsymmetricPercentileInterval(5, 90),
+                            image_label='first')
+        self.image.set_stretch(apviz.LogStretch(), image_label='first')
+        self.image.set_colormap('viridis', image_label='first')
 
-        self.image.load_image(arr, image_label="second")
-        self.image.set_cuts(
-            apviz.ManualInterval(1100, 1300), image_label="second"
-        )
-        self.image.set_stretch(apviz.SqrtStretch(), image_label="second")
-        self.image.set_colormap("plasma", image_label="second")
+        second_cuts = apviz.ManualInterval(1100, 1300)
+        second_stretch = apviz.SqrtStretch()
+        self.image.load_image(arr, image_label='second')
+        self.image.set_cuts(second_cuts, image_label='second')
+        self.image.set_stretch(second_stretch, image_label='second')
+        self.image.set_colormap('plasma', image_label='second')
 
         new_arr = arr + 10
-        self.image.load_image(new_arr, image_label="first")
+        self.image.load_image(new_arr, image_label='first')
 
-        assert self.image.get_cuts(image_label="first") is first_cuts
-        assert self.image.get_stretch(image_label="first") is first_stretch
-        assert self.image.get_colormap(image_label="first") == "viridis"
-        assert self.image._astro_im._image.scales["image"].colors == bqcolors(
-            "viridis"
-        )
+        assert self.image.get_cuts(image_label='first') is second_cuts
+        assert self.image.get_stretch(image_label='first') is second_stretch
+        assert self.image.get_colormap(image_label='first') == 'plasma'
+        assert self.image._astro_im._image.scales['image'].colors == bqcolors('plasma')
 
         displayed = np.asarray(self.image._astro_im._image.image)
-        np.testing.assert_allclose(
-            displayed, first_stretch(first_cuts(new_arr))
-        )
+        np.testing.assert_allclose(displayed, second_stretch(second_cuts(new_arr)))
 
     def test_load_image_keeps_settings_without_labels(self):
         # The carry-forward of cuts, stretch and colormap must work in the
         # common interactive case where no image_label is ever passed, so
-        # every image and its settings live under the API's default (None)
-        # label. Loading a second image must keep the settings currently in
-        # effect, not fall back to the widget defaults.
+        # every image gets a generated label. Loading a second image must
+        # display it with the settings currently in effect, not fall back
+        # to the widget defaults.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
@@ -213,59 +236,51 @@ class TestBQplotWidget(ImageAPITest):
         stretch = apviz.LogStretch()
         self.image.set_cuts(cuts)
         self.image.set_stretch(stretch)
-        self.image.set_colormap("viridis")
+        self.image.set_colormap('viridis')
 
         # A differently shaped second image, still with no label.
         arr2 = rng.integers(1100, 1300, size=(40, 30)).astype(np.uint16)
         arr2[10, 15] = 65535
         self.image.load_image(arr2)
 
-        assert self.image.get_cuts() is cuts
-        assert self.image.get_stretch() is stretch
-        assert self.image.get_colormap() == "viridis"
-        assert self.image._astro_im._image.scales["image"].colors == bqcolors(
-            "viridis"
-        )
+        # Both images stay loaded under generated labels, so the get_*
+        # methods need a label; ask about the displayed (new) image.
+        displayed_label = self.image._displayed_image_labels[0]
+        assert self.image.get_cuts(image_label=displayed_label) is cuts
+        assert self.image.get_stretch(image_label=displayed_label) is stretch
+        assert self.image.get_colormap(image_label=displayed_label) == 'viridis'
+        assert self.image._astro_im._image.scales['image'].colors == bqcolors('viridis')
 
         displayed = np.asarray(self.image._astro_im._image.image)
         np.testing.assert_allclose(displayed, stretch(cuts(arr2)))
 
-    def test_load_image_without_label_targets_single_labeled_image(self):
-        # An image label of None means "the caller did not specify a
-        # label". Once a labeled image exists, the API layer resolves None
-        # to that label, so an unlabeled load replaces the labeled image
-        # (keeping its settings) and never touches an image stored under
-        # the None label. With two or more labels the target is ambiguous
-        # and the load raises.
+    def test_load_image_without_label_never_replaces(self):
+        # An unlabeled load gets a generated label, so it can never
+        # silently replace a previously loaded image: the labeled image
+        # keeps its data and settings, while the new image takes over the
+        # display with those settings carried forward.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
 
-        unlabeled_cuts = apviz.AsymmetricPercentileInterval(5, 90)
-        self.image.load_image(arr)
-        self.image.set_cuts(unlabeled_cuts)
-
         labeled_cuts = apviz.ManualInterval(1100, 1300)
-        self.image.load_image(arr + 1, image_label="labeled")
-        self.image.set_cuts(labeled_cuts, image_label="labeled")
+        self.image.load_image(arr, image_label='labeled')
+        self.image.set_cuts(labeled_cuts, image_label='labeled')
 
         self.image.load_image(arr + 2)
 
-        # The unlabeled load replaced the labeled image and kept its cuts.
+        # The labeled image is untouched...
         np.testing.assert_array_equal(
-            np.asarray(self.image.get_image(image_label="labeled")), arr + 2
-        )
-        assert self.image.get_cuts(image_label="labeled") is labeled_cuts
+            np.asarray(self.image.get_image(image_label='labeled')), arr)
+        assert self.image.get_cuts(image_label='labeled') is labeled_cuts
 
-        # The image stored under the None label kept its own settings.
-        # Once a user label exists, get_cuts(image_label=None) resolves to
-        # that label, so look at the stored settings directly.
-        assert self.image._images[None].cuts is unlabeled_cuts
-
-        # With two user-defined labels an unlabeled load is ambiguous.
-        self.image.load_image(arr, image_label="labeled2")
-        with pytest.raises(ValueError, match="Multiple image labels"):
-            self.image.load_image(arr)
+        # ...and the new image is displayed, under a generated label, with
+        # the displayed settings carried forward.
+        new_label = self.image._displayed_image_labels[0]
+        assert new_label != 'labeled'
+        np.testing.assert_array_equal(
+            np.asarray(self.image.get_image(image_label=new_label)), arr + 2)
+        assert self.image.get_cuts(image_label=new_label) is labeled_cuts
 
     def test_first_load_stores_widget_default_cuts(self):
         # With nothing loaded yet there are no current settings to carry
@@ -327,33 +342,33 @@ class TestBQplotWidget(ImageAPITest):
         # produced a series of visible intermediate states (flicker).
         # Loading should batch the updates so the image mark and each
         # scale send at most one state message.
-        self.image.load_image(data, image_label="first")
+        self.image.load_image(data, image_label='first')
         # Cuts that differ from the widget default, so the end-state check
         # below can tell the carried-forward settings from a fallback to
         # the defaults.
         cuts = apviz.AsymmetricPercentileInterval(5, 90)
-        self.image.set_cuts(cuts, image_label="first")
+        self.image.set_cuts(cuts, image_label='first')
 
         astro_im = self.image._astro_im
         image_mark = astro_im._image
-        scale_x = astro_im._scales["x"]
-        scale_y = astro_im._scales["y"]
+        scale_x = astro_im._scales['x']
+        scale_y = astro_im._scales['y']
 
         # Use a different shape so the image extent and scales all change.
         arr = np.arange(30 * 40, dtype=float).reshape(30, 40)
 
-        spy_image = mocker.spy(image_mark, "send_state")
-        spy_x = mocker.spy(scale_x, "send_state")
-        spy_y = mocker.spy(scale_y, "send_state")
+        spy_image = mocker.spy(image_mark, 'send_state')
+        spy_x = mocker.spy(scale_x, 'send_state')
+        spy_y = mocker.spy(scale_y, 'send_state')
 
-        self.image.load_image(arr, image_label="second")
+        self.image.load_image(arr, image_label='second')
 
         assert spy_image.call_count <= 1
         assert spy_x.call_count <= 1
         assert spy_y.call_count <= 1
 
         # Batching must not change the end state.
-        assert self.image.get_cuts(image_label="second") is cuts
+        assert self.image.get_cuts(image_label='second') is cuts
         displayed = np.asarray(image_mark.image)
         np.testing.assert_allclose(displayed, cuts(arr))
         np.testing.assert_allclose(image_mark.x, [-0.5, arr.shape[1] - 0.5])
@@ -365,12 +380,12 @@ class TestBQplotWidget(ImageAPITest):
         # If a scale syncs before the image mark, the front end briefly
         # draws the OLD image against the NEW scales (a visible refit).
         # The new image data must reach the front end first.
-        self.image.load_image(data, image_label="first")
+        self.image.load_image(data, image_label='first')
 
         astro_im = self.image._astro_im
         image_mark = astro_im._image
-        scale_x = astro_im._scales["x"]
-        scale_y = astro_im._scales["y"]
+        scale_x = astro_im._scales['x']
+        scale_y = astro_im._scales['y']
 
         # A different shape so the image extent and both scales change.
         arr = np.arange(30 * 40, dtype=float).reshape(30, 40)
@@ -384,17 +399,17 @@ class TestBQplotWidget(ImageAPITest):
                 order.append(name)
                 return real(*args, **kwargs)
 
-            mocker.patch.object(widget, "send_state", side_effect=wrapper)
+            mocker.patch.object(widget, 'send_state', side_effect=wrapper)
 
-        record("image", image_mark)
-        record("scale_x", scale_x)
-        record("scale_y", scale_y)
+        record('image', image_mark)
+        record('scale_x', scale_x)
+        record('scale_y', scale_y)
 
-        self.image.load_image(arr, image_label="second")
+        self.image.load_image(arr, image_label='second')
 
-        assert "image" in order
-        assert order.index("image") < order.index("scale_x")
-        assert order.index("image") < order.index("scale_y")
+        assert 'image' in order
+        assert order.index('image') < order.index('scale_x')
+        assert order.index('image') < order.index('scale_y')
 
     def test_get_viewport_reflects_interactive_pan(self, data):
         # Panning in the browser shifts the bqplot scales directly. Simulate
@@ -407,18 +422,18 @@ class TestBQplotWidget(ImageAPITest):
         # Horizontal pan: shift the x scale. Set min before max so that the
         # center is already correct when the 'max' observer fires.
         dx = 20
-        scales["x"].min += dx
-        scales["x"].max += dx
+        scales['x'].min += dx
+        scales['x'].max += dx
 
-        vp = self.image.get_viewport(sky_or_pixel="pixel")
-        assert vp["center"][0] == pytest.approx(75 + dx)
-        assert vp["center"][1] == pytest.approx(50)
+        vp = self.image.get_viewport(sky_or_pixel='pixel')
+        assert vp['center'][0] == pytest.approx(75 + dx)
+        assert vp['center'][1] == pytest.approx(50)
 
         # Vertical pan: shift the y scale.
         dy = -15
-        scales["y"].min += dy
-        scales["y"].max += dy
+        scales['y'].min += dy
+        scales['y'].max += dy
 
-        vp = self.image.get_viewport(sky_or_pixel="pixel")
-        assert vp["center"][0] == pytest.approx(75 + dx)
-        assert vp["center"][1] == pytest.approx(50 + dy)
+        vp = self.image.get_viewport(sky_or_pixel='pixel')
+        assert vp['center'][0] == pytest.approx(75 + dx)
+        assert vp['center'][1] == pytest.approx(50 + dy)

--- a/astrowidgets/tests/test_widget_api_bqplot.py
+++ b/astrowidgets/tests/test_widget_api_bqplot.py
@@ -161,12 +161,11 @@ class TestBQplotWidget(ImageAPITest):
         assert self.image.get_colormap() == 'Greys_r'
         assert self.image._astro_im._image.scales['image'].colors == greys_r
 
-    def test_load_image_keeps_current_display_settings(self):
-        # Loading a new image should display it with the cuts, stretch and
-        # colormap that are currently in effect, carried forward from the
-        # previously displayed image, and store them for the new image so
-        # that the get_* methods agree with the display. Only the viewport
-        # resets on load.
+    def test_load_image_new_label_gets_default_settings(self):
+        # Loading an image under a new label should display it with the
+        # widget's default cuts, stretch and colormap -- not settings
+        # carried forward from the previously displayed image -- and the
+        # previous label keeps its own settings untouched.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
@@ -180,46 +179,54 @@ class TestBQplotWidget(ImageAPITest):
 
         self.image.load_image(arr, image_label='second')
 
-        assert self.image.get_cuts(image_label='second') is cuts
-        assert self.image.get_stretch(image_label='second') is stretch
-        assert self.image.get_colormap(image_label='second') == 'viridis'
-        assert self.image._astro_im._image.scales['image'].colors == bqcolors('viridis')
+        second_cuts = self.image.get_cuts(image_label='second')
+        assert isinstance(second_cuts, apviz.AsymmetricPercentileInterval)
+        assert second_cuts.lower_percentile == 30
+        assert second_cuts.upper_percentile == 96
+        assert isinstance(self.image.get_stretch(image_label='second'),
+                          apviz.LinearStretch)
+        assert self.image.get_colormap(image_label='second') == 'Greys_r'
+        assert self.image._astro_im._image.scales['image'].colors == bqcolors('Greys_r')
 
         displayed = np.asarray(self.image._astro_im._image.image)
-        np.testing.assert_allclose(displayed, stretch(cuts(arr)))
+        np.testing.assert_allclose(displayed, second_cuts(arr))
 
-    def test_reload_existing_label_carries_displayed_settings(self):
-        # Loading data under an existing image label follows the same
-        # carry-forward rule as any other load: the settings of the image
-        # being replaced on the display -- not the reloaded label's old
-        # settings -- are carried to the new image and shown.
+        # The first label's settings are untouched.
+        assert self.image.get_cuts(image_label='first') is cuts
+        assert self.image.get_stretch(image_label='first') is stretch
+        assert self.image.get_colormap(image_label='first') == 'viridis'
+
+    def test_reload_existing_label_keeps_its_settings(self):
+        # Loading new data under an existing image label keeps the settings
+        # already stored for that label -- not the settings of the image it
+        # replaces on the display -- and redisplays with them.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
 
+        first_cuts = apviz.AsymmetricPercentileInterval(5, 90)
+        first_stretch = apviz.LogStretch()
         self.image.load_image(arr, image_label='first')
-        self.image.set_cuts(apviz.AsymmetricPercentileInterval(5, 90),
-                            image_label='first')
-        self.image.set_stretch(apviz.LogStretch(), image_label='first')
+        self.image.set_cuts(first_cuts, image_label='first')
+        self.image.set_stretch(first_stretch, image_label='first')
         self.image.set_colormap('viridis', image_label='first')
 
-        second_cuts = apviz.ManualInterval(1100, 1300)
-        second_stretch = apviz.SqrtStretch()
         self.image.load_image(arr, image_label='second')
-        self.image.set_cuts(second_cuts, image_label='second')
-        self.image.set_stretch(second_stretch, image_label='second')
+        self.image.set_cuts(apviz.ManualInterval(1100, 1300),
+                            image_label='second')
+        self.image.set_stretch(apviz.SqrtStretch(), image_label='second')
         self.image.set_colormap('plasma', image_label='second')
 
         new_arr = arr + 10
         self.image.load_image(new_arr, image_label='first')
 
-        assert self.image.get_cuts(image_label='first') is second_cuts
-        assert self.image.get_stretch(image_label='first') is second_stretch
-        assert self.image.get_colormap(image_label='first') == 'plasma'
-        assert self.image._astro_im._image.scales['image'].colors == bqcolors('plasma')
+        assert self.image.get_cuts(image_label='first') is first_cuts
+        assert self.image.get_stretch(image_label='first') is first_stretch
+        assert self.image.get_colormap(image_label='first') == 'viridis'
+        assert self.image._astro_im._image.scales['image'].colors == bqcolors('viridis')
 
         displayed = np.asarray(self.image._astro_im._image.image)
-        np.testing.assert_allclose(displayed, second_stretch(second_cuts(new_arr)))
+        np.testing.assert_allclose(displayed, first_stretch(first_cuts(new_arr)))
 
     def test_load_image_keeps_settings_without_labels(self):
         # The carry-forward of cuts, stretch and colormap must work in the
@@ -258,7 +265,7 @@ class TestBQplotWidget(ImageAPITest):
         # An unlabeled load gets a generated label, so it can never
         # silently replace a previously loaded image: the labeled image
         # keeps its data and settings, while the new image takes over the
-        # display with those settings carried forward.
+        # display with the widget's default settings.
         rng = np.random.default_rng(seed=42)
         arr = rng.integers(1100, 1300, size=(50, 60)).astype(np.uint16)
         arr[25, 30] = 65535
@@ -275,12 +282,16 @@ class TestBQplotWidget(ImageAPITest):
         assert self.image.get_cuts(image_label='labeled') is labeled_cuts
 
         # ...and the new image is displayed, under a generated label, with
-        # the displayed settings carried forward.
+        # the widget's default cuts rather than the labeled image's.
         new_label = self.image._displayed_image_labels[0]
         assert new_label != 'labeled'
         np.testing.assert_array_equal(
             np.asarray(self.image.get_image(image_label=new_label)), arr + 2)
-        assert self.image.get_cuts(image_label=new_label) is labeled_cuts
+        new_cuts = self.image.get_cuts(image_label=new_label)
+        assert new_cuts is not labeled_cuts
+        assert isinstance(new_cuts, apviz.AsymmetricPercentileInterval)
+        assert new_cuts.lower_percentile == 30
+        assert new_cuts.upper_percentile == 96
 
     def test_first_load_stores_widget_default_cuts(self):
         # With nothing loaded yet there are no current settings to carry
@@ -343,11 +354,6 @@ class TestBQplotWidget(ImageAPITest):
         # Loading should batch the updates so the image mark and each
         # scale send at most one state message.
         self.image.load_image(data, image_label='first')
-        # Cuts that differ from the widget default, so the end-state check
-        # below can tell the carried-forward settings from a fallback to
-        # the defaults.
-        cuts = apviz.AsymmetricPercentileInterval(5, 90)
-        self.image.set_cuts(cuts, image_label='first')
 
         astro_im = self.image._astro_im
         image_mark = astro_im._image
@@ -367,8 +373,10 @@ class TestBQplotWidget(ImageAPITest):
         assert spy_x.call_count <= 1
         assert spy_y.call_count <= 1
 
-        # Batching must not change the end state.
-        assert self.image.get_cuts(image_label='second') is cuts
+        # Batching must not change the end state: the new label is displayed
+        # with the widget's default cuts.
+        cuts = self.image.get_cuts(image_label='second')
+        assert isinstance(cuts, apviz.AsymmetricPercentileInterval)
         displayed = np.asarray(image_mark.image)
         np.testing.assert_allclose(displayed, cuts(arr))
         np.testing.assert_allclose(image_mark.x, [-0.5, arr.shape[1] - 0.5])


### PR DESCRIPTION
This slims the bqplot backend down to the rendering-hook interface added to `ImageViewerLogic` in astro-image-display-api 0.3.0 (the template-method refactor).

Now that #205 and #214 have merged, this branch has been rebased onto `main` and contains only this PR's three commits; the diff is just `astrowidgets/bqplot.py` and its test file. The `astro-image-display-api>=0.3.0` pin (released) landed with #214.

Closes #213.

### What changed

- Deleted the public-method wrappers (`load_image`, `set_cuts`, `set_stretch`, `set_colormap`, `set_viewport`, `get_viewport`, `load_catalog`, `set_catalog_style`, `remove_catalog`), including `load_image`'s carry-forward block, which now lives upstream. The display glue moved into the hooks: `_render_image`, `_apply_cuts`, `_apply_stretch`, `_apply_colormap`, `_apply_viewport`, `_draw_catalog`, `_remove_catalog_marks`, built on the existing internals (`_refresh_display`, `_send_data`, `plot_named_markers`/`remove_named_markers`).
- `_batch_update` composes the two existing batching context managers via an `ExitStack`: the front-end sync of the image mark and the scales is held for the whole block (one state message per widget, image mark flushing first, so no flicker or refit flash), and the refreshes triggered by the `_apply_*` hooks are deferred and collapsed into a single recomputation of the displayed array that runs while the sync is still held. The existing batching regression tests pass unchanged.
- Because the hooks receive resolved labels, the catalog scatter marks are always stored under the resolved catalog label — fixes #213 (unlabeled `set_catalog_style` plotted an orphan mark under the id `"None"`; unlabeled `remove_catalog` raised). Regression tests added.
- Fixed a latent `__init__` bug: the default colormap was stored through `set_colormap` before any image was loaded, which now raises. The default is applied directly to the front end instead, and `_render_image` stores the widget defaults (Greys_r, 30–96 percentile cuts) for the first image displayed, i.e. a load with nothing to carry forward.
- Deleted the local `docs_from_super_if_missing` in favor of the upstream decorator, and the `_current_image_label` property; the GUI pan/zoom observer now targets the displayed image's label explicitly.
- Marker interaction helpers and the rest of the bqplot-specific public API are untouched.
- Widget tests that encoded the old None-label and reload semantics are updated to the released AIDA 0.3.0 behavior: an unlabeled load targets the single shared default label, so repeated unlabeled loads replace each other while never touching an explicitly labeled image (see the review discussion below).

`test_widget_api_bqplot.py` passes in full (97 passed, 2 skipped) and the ginga suite is unaffected (110 passed); lint (`ruff check astrowidgets`) is clean.

Generated by Claude Code at Matt Craig's direction.
