### PR TITLE
Switching to ruff linter

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -25,10 +25,10 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.x'
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        python -m pip install --upgrade pip flake8
-        flake8 astrowidgets --count
+        python -m pip install --upgrade pip ruff
+        ruff check astrowidgets
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@
 # be accessible, and the documentation will not build correctly.
 
 import datetime
-import os
 import sys
 from pathlib import Path
 import tomllib
@@ -34,7 +33,8 @@ import tomllib
 from astrowidgets import __version__ as aw_version
 
 try:
-    from sphinx_astropy.conf.v1 import *  # noqa
+    from sphinx_astropy.conf.v1 import *
+    from sphinx_astropy.conf.v1 import rst_epilog, exclude_patterns  # noqa
 except ImportError:
     print(
         "ERROR: the documentation requires the sphinx-astropy package to be installed"

--- a/example_notebooks/bqplot_widget.ipynb
+++ b/example_notebooks/bqplot_widget.ipynb
@@ -151,7 +151,6 @@
    "outputs": [],
    "source": [
     "# Set cuts using API -- any astropy interval works\n",
-    "from astropy.visualization import AsymmetricPercentileInterval\n",
     "w.set_cuts(AsymmetricPercentileInterval(1, 99.9))"
    ]
   },
@@ -330,7 +329,7 @@
    "source": [
     "# Note: stretch_options is not part of the astro-image-display-api\n",
     "# The API uses astropy visualization stretch objects\n",
-    "from astropy.visualization import LinearStretch, LogStretch, SqrtStretch, PowerStretch\n",
+    "from astropy.visualization import LogStretch\n",
     "print(\"Available stretch types: LinearStretch, LogStretch, SqrtStretch, PowerStretch, etc.\")"
    ]
   },
@@ -351,7 +350,6 @@
    "outputs": [],
    "source": [
     "# Change the stretch using astropy visualization objects\n",
-    "from astropy.visualization import LogStretch\n",
     "w.set_stretch(LogStretch())\n",
     "print(w.get_stretch())"
    ]
@@ -364,7 +362,7 @@
    "source": [
     "# Note: autocut_options is not part of the astro-image-display-api\n",
     "# The API uses astropy visualization interval objects\n",
-    "from astropy.visualization import MinMaxInterval, PercentileInterval, AsymmetricPercentileInterval\n",
+    "from astropy.visualization import PercentileInterval, AsymmetricPercentileInterval\n",
     "print(\"Available cuts types: MinMaxInterval, PercentileInterval, AsymmetricPercentileInterval, etc.\")"
    ]
   },
@@ -396,7 +394,6 @@
    "outputs": [],
    "source": [
     "# Change the cuts with an astropy visualization interval object\n",
-    "from astropy.visualization import PercentileInterval\n",
     "w.set_cuts(PercentileInterval(95))\n",
     "print(w.get_cuts())"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,11 @@ build-backend = 'setuptools.build_meta'
 [tool.setuptools]
 packages = ["astrowidgets"]
 
-[tool.flake8]
-extend-ignore = ["E501", "W503"]
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
+extend-ignore = ["E501", "E402", "F403"]
 
 [tool.pytest.ini_options]
 astropy_header = true


### PR DESCRIPTION
Updating to a more modern linter. Made some small changes to fix things. Using the old 79 per line character limit. E402 is for where imports are in ipynb cells (irrelevant for just checking in `astrowidgets`, but I wanted to test `ruff check .`), and F403 lets us do the star import in `docs/conf.py` (again, not in `astrowidgets` but still trying to run on all).