### PR TITLE
Factor the cursor-info readout into a module shared by both backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,27 @@
 
 TBD -- First stable release.
 
+New Features
+------------
+
+- The cursor-information readout (X/Y, RA/Dec, pixel value) is now shared
+  between the ginga and bqplot backends via
+  ``astrowidgets.cursor_info.CursorInfoMixin``. The ``cursor`` property
+  ('top', 'bottom', or ``None``), which had been dropped from the bqplot
+  backend, is available again on both backends, and a new
+  ``sky_coordinate_format`` property selects between decimal degrees (the
+  new default for both backends) and sexagesimal for the RA/Dec display.
+  As part of this change the ginga readout switched from sexagesimal to
+  decimal degrees by default; set ``sky_coordinate_format`` to
+  ``'sexagesimal'`` for the previous behavior.
+
 Bug Fixes
 ---------
+
+- Fixed the RA/Dec shown in the bqplot ``ImageWidget`` cursor readout,
+  which transposed the x and y pixel coordinates when converting to sky
+  coordinates. Also fixed both backends reading pixel 0's value for
+  cursor positions slightly outside the image on the negative side.
 
 - Fixed the bqplot ``ImageWidget`` so that mouse clicks no longer raise
   ``AttributeError`` and no longer block user-registered ``on_msg``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,14 +8,12 @@ New Features
 
 - The cursor-information readout (X/Y, RA/Dec, pixel value) is now shared
   between the ginga and bqplot backends via
-  ``astrowidgets.cursor_info.CursorInfoMixin``. The ``cursor`` property
-  ('top', 'bottom', or ``None``), which had been dropped from the bqplot
-  backend, is available again on both backends, and a new
-  ``sky_coordinate_format`` property selects between decimal degrees (the
-  new default for both backends) and sexagesimal for the RA/Dec display.
-  As part of this change the ginga readout switched from sexagesimal to
-  decimal degrees by default; set ``sky_coordinate_format`` to
-  ``'sexagesimal'`` for the previous behavior.
+  ``astrowidgets.cursor_info.CursorInfoMixin``. Both backends have a
+  ``cursor`` property (``'top'``, ``'bottom'``, or ``None``) and a new
+  ``sky_coordinate_format`` property that selects decimal degrees (the
+  default) or sexagesimal for the RA/Dec display. The ginga readout now
+  defaults to decimal degrees; set ``sky_coordinate_format`` to
+  ``'sexagesimal'`` for the previous display. [#222]
 
 Bug Fixes
 ---------

--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -396,7 +396,7 @@ class ImageWidget(ipw.VBox, CursorInfoMixin, ImageViewerLogic):
 
         self._init_mouse_callbacks()
         self._init_watch_image_changes()
-        self._init_cursor_info(self._astro_im)
+        self.children = [self._astro_im, self._init_cursor_info()]
 
     def _init_mouse_callbacks(self):
 

--- a/astrowidgets/bqplot.py
+++ b/astrowidgets/bqplot.py
@@ -20,6 +20,8 @@ from astro_image_display_api.image_viewer_logic import (
     docs_from_image_viewer_logic_if_missing,
 )
 
+from astrowidgets.cursor_info import CursorInfoMixin
+
 
 class _AstroImage(ipw.VBox):
     """
@@ -354,7 +356,7 @@ def bqcolors(colormap, reverse=False):
 
 # The inheritance order below matters -- VBox needs to come first
 @docs_from_image_viewer_logic_if_missing
-class ImageWidget(ipw.VBox, ImageViewerLogic):
+class ImageWidget(ipw.VBox, CursorInfoMixin, ImageViewerLogic):
     def __init__(self, *args, display_width=500, display_aspect_ratio=1):
         super().__init__(*args)
         # ImageViewerLogic is a dataclass; we do not run its __init__, so run
@@ -392,11 +394,9 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         # debugging.
         self._print_out = ipw.Output()
 
-        self._cursor = ipw.HTML('Coordinates show up here')
-
         self._init_mouse_callbacks()
         self._init_watch_image_changes()
-        self.children = [self._astro_im, self._cursor]
+        self._init_cursor_info(self._astro_im)
 
     def _init_mouse_callbacks(self):
 
@@ -415,36 +415,8 @@ class ImageWidget(ipw.VBox, ImageViewerLogic):
         self._astro_im.interaction.on_msg(on_mouse_message)
 
     def _mouse_move(self, event_data):
-        if self._data is None:
-            # Nothing to display, so exit
-            return
-
-        xc = event_data['domain']['x']
-        yc = event_data['domain']['y']
-
-        # get the array indices into the data so that we can get data values
-        x_index = int(np.floor(xc + 0.5))
-        y_index = int(np.floor(yc + 0.5))
-
-        # Check that the index is in the array.
-        in_image = (self._data.shape[1] > x_index >= 0) and (self._data.shape[0] > y_index >= 0)
-        if in_image:
-            val = self._data[y_index, x_index]
-        else:
-            val = None
-
-        if val is not None:
-            value = f'value: {val:8.3f}'
-        else:
-            value = 'value: N/A'
-
-        pixel_location = f'X:  {xc:.2f}  Y:  {yc:.2f}'
-        if self._wcs is not None:
-            sky = self._wcs.pixel_to_world(yc, xc)
-            ra_dec = f'RA: {sky.icrs.ra:3.7f} Dec: {sky.icrs.dec:3.7f}'
-        else:
-            ra_dec = ''
-        self._cursor.value = ', '.join([pixel_location, ra_dec, value])
+        self._update_cursor_text(event_data['domain']['x'],
+                                 event_data['domain']['y'])
 
     def _mouse_click(self, event_data):
         if self._data is None:

--- a/astrowidgets/cursor_info.py
+++ b/astrowidgets/cursor_info.py
@@ -63,6 +63,9 @@ def format_cursor_text(x, y, data=None, wcs=None, sky_format='degrees'):
         raise ValueError(f'Invalid value {sky_format!r} for sky_format. '
                          f'Valid values are: {ALLOWED_SKY_COORDINATE_FORMATS}')
 
+    if data is not None:
+        data = np.asarray(data)
+
     # floor rather than int() so that positions just outside the image on
     # the negative side do not alias onto pixel 0.
     x_index = int(np.floor(x + 0.5))
@@ -93,6 +96,11 @@ def format_cursor_text(x, y, data=None, wcs=None, sky_format='degrees'):
                 dec = f'{sky.dec.deg:<+8.4f}'
             segments.append(f'RA: {ra} Dec: {dec} (ICRS)')
         except Exception:
+            # Deliberately broad: the WCS is user-supplied and only
+            # duck-typed to the APE-14 interface, so the exceptions it can
+            # raise are open-ended, and this runs on every mouse move,
+            # where an escaped exception would spam the log or vanish
+            # instead of surfacing cleanly. Degrade to a visible error.
             segments.append('RA/Dec: WCS error')
 
     segments.append(value)
@@ -107,21 +115,24 @@ class CursorInfoMixin:
     `~astro_image_display_api.image_viewer_logic.ImageViewerLogic`, whose
     per-label image storage supplies the data and WCS for the readout.
     The mixin defines no ``__init__``; backends call `_init_cursor_info`
-    from their own ``__init__`` and forward their native mouse-move
-    events to `_update_cursor_text`.
+    from their own ``__init__``, place the returned readout widget in
+    their own ``children``, and forward their native mouse-move events
+    to `_update_cursor_text`.
     """
     ALLOWED_CURSOR_LOCATIONS = ALLOWED_CURSOR_LOCATIONS
     ALLOWED_SKY_COORDINATE_FORMATS = ALLOWED_SKY_COORDINATE_FORMATS
 
-    def _init_cursor_info(self, image_widget):
+    def _init_cursor_info(self):
         """
-        Create the readout widget and lay it out below ``image_widget``.
+        Create and return the readout widget. The backend adds it to its
+        own ``children``, below the image widget; the `cursor` property
+        flips the box to ``column-reverse`` to show it on top.
         """
         self._cursor_readout = ipw.HTML('Coordinates show up here')
         self._sky_coordinate_format = 'degrees'
         self._last_cursor_position = None
-        self.children = [image_widget, self._cursor_readout]
         self.cursor = 'bottom'
+        return self._cursor_readout
 
     @property
     def cursor(self):
@@ -133,6 +144,18 @@ class CursorInfoMixin:
 
     @cursor.setter
     def cursor(self, val):
+        """
+        Set the readout location.
+
+        Parameters
+        ----------
+        val : str or None
+            One of `ALLOWED_CURSOR_LOCATIONS`: ``'top'`` or ``'bottom'``
+            place the readout above or below the image by flipping the
+            box's flex direction; ``None`` hides it. The readout is
+            re-rendered at the last cursor position. Anything else
+            raises `ValueError`.
+        """
         if val is None:
             self._cursor_readout.layout.visibility = 'hidden'
             self._cursor_readout.layout.display = 'none'
@@ -159,6 +182,18 @@ class CursorInfoMixin:
 
     @sky_coordinate_format.setter
     def sky_coordinate_format(self, val):
+        """
+        Set the RA/Dec display format.
+
+        Parameters
+        ----------
+        val : str
+            One of `ALLOWED_SKY_COORDINATE_FORMATS`: ``'degrees'`` or
+            ``'sexagesimal'``. The readout is immediately re-rendered
+            at the last cursor position, so the change is visible
+            without waiting for the next mouse move. Anything else
+            raises `ValueError`.
+        """
         if val not in self.ALLOWED_SKY_COORDINATE_FORMATS:
             raise ValueError('Invalid value {} for sky_coordinate_format. '
                              'Valid values are: '
@@ -171,6 +206,13 @@ class CursorInfoMixin:
         """
         Update the readout for a cursor at ``(x, y)`` in data coordinates,
         using the data and WCS of the currently displayed image.
+
+        Parameters
+        ----------
+        x, y : float
+            Cursor position in data (pixel) coordinates, following the
+            `astropy.wcs.WCS.pixel_to_world` convention (pixel centers
+            at integer values, origin 0).
         """
         self._last_cursor_position = (x, y)
         self._refresh_cursor_text()
@@ -189,8 +231,6 @@ class CursorInfoMixin:
         data = info.data
         if isinstance(data, NDData):
             data = data.data
-        elif data is not None:
-            data = np.asarray(data)
 
         self._cursor_readout.value = READOUT_TEMPLATE.format(
             format_cursor_text(x, y, data=data, wcs=info.wcs,

--- a/astrowidgets/cursor_info.py
+++ b/astrowidgets/cursor_info.py
@@ -1,0 +1,197 @@
+"""
+Shared cursor-information readout for astrowidgets backends.
+
+Backends compose their image widget with an HTML readout that shows the
+cursor position (X/Y and, when a WCS is available, RA/Dec) and the image
+value under the cursor. The formatting and widget plumbing live here so
+that every backend behaves the same; each backend only forwards its
+native mouse-move events to `CursorInfoMixin._update_cursor_text`.
+"""
+import numpy as np
+
+from astropy import units as u
+from astropy.nddata import NDData
+
+import ipywidgets as ipw
+
+__all__ = ['format_cursor_text', 'CursorInfoMixin', 'READOUT_TEMPLATE',
+           'ALLOWED_CURSOR_LOCATIONS', 'ALLOWED_SKY_COORDINATE_FORMATS']
+
+ALLOWED_CURSOR_LOCATIONS = ('top', 'bottom', None)
+ALLOWED_SKY_COORDINATE_FORMATS = ('degrees', 'sexagesimal')
+
+# The readout is rendered in a <pre> so that the fixed-width padding in
+# format_cursor_text survives HTML whitespace collapsing and the digits
+# line up, keeping the line from jittering as the cursor moves.
+READOUT_TEMPLATE = '<pre style="margin: 0">{}</pre>'
+
+
+def format_cursor_text(x, y, data=None, wcs=None, sky_format='degrees'):
+    """
+    Format the cursor readout for a position in an image.
+
+    Parameters
+    ----------
+    x, y : float
+        Cursor position in data (pixel) coordinates, with pixel centers
+        at integer values (origin 0), i.e. the convention of
+        `astropy.wcs.WCS.pixel_to_world`.
+    data : array-like or None
+        Image data, indexed as ``data[y, x]``. When ``None``, or when the
+        cursor is outside the array, the value reads ``N/A``.
+    wcs : `astropy.wcs.WCS` or None
+        WCS used for the RA/Dec segment; omitted when ``None``. The sky
+        position is always converted to ICRS, whatever the native frame
+        of the WCS, and the segment is tagged ``(ICRS)`` to say so.
+    sky_format : str
+        One of `ALLOWED_SKY_COORDINATE_FORMATS`. ``'degrees'`` shows
+        decimal degrees, ``'sexagesimal'`` shows ``HH:MM:SS.ss`` /
+        ``±DD:MM:SS.ss``.
+
+    Returns
+    -------
+    str
+        Readout like ``'X: 10    Y: 7     RA: 137.0412 Dec:
+        -10.1235 (ICRS) value: 3.1'``. X/Y show the integer pixel the
+        value is sampled from. The X/Y and decimal RA/Dec fields are
+        fixed width, left-aligned so the padding trails the numbers and
+        the line does not jitter as the cursor moves (sexagesimal is
+        naturally fixed width); at their widest, fields are followed by
+        a single space.
+    """
+    if sky_format not in ALLOWED_SKY_COORDINATE_FORMATS:
+        raise ValueError(f'Invalid value {sky_format!r} for sky_format. '
+                         f'Valid values are: {ALLOWED_SKY_COORDINATE_FORMATS}')
+
+    # floor rather than int() so that positions just outside the image on
+    # the negative side do not alias onto pixel 0.
+    x_index = int(np.floor(x + 0.5))
+    y_index = int(np.floor(y + 0.5))
+
+    if (data is not None
+            and 0 <= y_index < data.shape[0]
+            and 0 <= x_index < data.shape[1]):
+        value = f'value: {data[y_index, x_index]:.1f}'
+    else:
+        value = 'value: N/A'
+
+    segments = [f'X: {x_index:<5d} Y: {y_index:<5d}']
+
+    if wcs is not None:
+        try:
+            sky = wcs.pixel_to_world(x, y).icrs
+            if sky_format == 'sexagesimal':
+                ra = sky.ra.to_string(unit=u.hour, sep=':',
+                                      precision=2, pad=True)
+                dec = sky.dec.to_string(unit=u.degree, sep=':',
+                                        precision=2, alwayssign=True,
+                                        pad=True)
+            else:
+                # Fixed width (RA 0-360, Dec always signed) so the line
+                # does not jitter as the cursor moves.
+                ra = f'{sky.ra.deg:<8.4f}'
+                dec = f'{sky.dec.deg:<+8.4f}'
+            segments.append(f'RA: {ra} Dec: {dec} (ICRS)')
+        except Exception:
+            segments.append('RA/Dec: WCS error')
+
+    segments.append(value)
+    return ' '.join(segments)
+
+
+class CursorInfoMixin:
+    """
+    Cursor-information readout shared by the astrowidgets backends.
+
+    Intended for `ipywidgets.VBox` subclasses that also inherit
+    `~astro_image_display_api.image_viewer_logic.ImageViewerLogic`, whose
+    per-label image storage supplies the data and WCS for the readout.
+    The mixin defines no ``__init__``; backends call `_init_cursor_info`
+    from their own ``__init__`` and forward their native mouse-move
+    events to `_update_cursor_text`.
+    """
+    ALLOWED_CURSOR_LOCATIONS = ALLOWED_CURSOR_LOCATIONS
+    ALLOWED_SKY_COORDINATE_FORMATS = ALLOWED_SKY_COORDINATE_FORMATS
+
+    def _init_cursor_info(self, image_widget):
+        """
+        Create the readout widget and lay it out below ``image_widget``.
+        """
+        self._cursor_readout = ipw.HTML('Coordinates show up here')
+        self._sky_coordinate_format = 'degrees'
+        self._last_cursor_position = None
+        self.children = [image_widget, self._cursor_readout]
+        self.cursor = 'bottom'
+
+    @property
+    def cursor(self):
+        """
+        Show or hide cursor information (X, Y, RA/Dec, value).
+        Acceptable values are 'top', 'bottom', or ``None``.
+        """
+        return self._cursor_location
+
+    @cursor.setter
+    def cursor(self, val):
+        if val is None:
+            self._cursor_readout.layout.visibility = 'hidden'
+            self._cursor_readout.layout.display = 'none'
+        elif val == 'top' or val == 'bottom':
+            self._cursor_readout.layout.visibility = 'visible'
+            self._cursor_readout.layout.display = 'flex'
+            if val == 'top':
+                self.layout.flex_flow = 'column-reverse'
+            else:
+                self.layout.flex_flow = 'column'
+        else:
+            raise ValueError('Invalid value {} for cursor. Valid values are: '
+                             '{}'.format(val, self.ALLOWED_CURSOR_LOCATIONS))
+        self._cursor_location = val
+        self._refresh_cursor_text()
+
+    @property
+    def sky_coordinate_format(self):
+        """
+        Format of the RA/Dec part of the cursor readout, either
+        ``'degrees'`` (decimal degrees, the default) or ``'sexagesimal'``.
+        """
+        return self._sky_coordinate_format
+
+    @sky_coordinate_format.setter
+    def sky_coordinate_format(self, val):
+        if val not in self.ALLOWED_SKY_COORDINATE_FORMATS:
+            raise ValueError('Invalid value {} for sky_coordinate_format. '
+                             'Valid values are: '
+                             '{}'.format(val,
+                                         self.ALLOWED_SKY_COORDINATE_FORMATS))
+        self._sky_coordinate_format = val
+        self._refresh_cursor_text()
+
+    def _update_cursor_text(self, x, y):
+        """
+        Update the readout for a cursor at ``(x, y)`` in data coordinates,
+        using the data and WCS of the currently displayed image.
+        """
+        self._last_cursor_position = (x, y)
+        self._refresh_cursor_text()
+
+    def _refresh_cursor_text(self):
+        """
+        Re-render the readout at the last known cursor position, e.g.
+        after the sky coordinate format changes.
+        """
+        if (self._last_cursor_position is None or self.cursor is None
+                or not self._displayed_image_labels):
+            return
+
+        x, y = self._last_cursor_position
+        info = self._images[self._displayed_image_labels[0]]
+        data = info.data
+        if isinstance(data, NDData):
+            data = data.data
+        elif data is not None:
+            data = np.asarray(data)
+
+        self._cursor_readout.value = READOUT_TEMPLATE.format(
+            format_cursor_text(x, y, data=data, wcs=info.wcs,
+                               sky_format=self._sky_coordinate_format))

--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -21,12 +21,13 @@ from ginga import cmap as ginga_cmap
 from ginga.AstroImage import AstroImage
 from ginga.canvas.CanvasObject import drawCatalog
 from ginga.web.jupyterw.ImageViewJpw import EnhancedCanvasView
-from ginga.util.wcs import ra_deg_to_str, dec_deg_to_str
 
 from astro_image_display_api.image_viewer_logic import (
     ImageViewerLogic,
     docs_from_image_viewer_logic_if_missing,
 )
+
+from astrowidgets.cursor_info import CursorInfoMixin
 
 __all__ = ['ImageWidget']
 
@@ -164,7 +165,7 @@ def _ginga_dist_for_stretch(stretch, hashsize):
 
 # The inheritance order below matters -- VBox needs to come first
 @docs_from_image_viewer_logic_if_missing
-class ImageWidget(ipyw.VBox, ImageViewerLogic):
+class ImageWidget(ipyw.VBox, CursorInfoMixin, ImageViewerLogic):
     """
     Image widget for Jupyter notebook using the Ginga viewer.
 
@@ -185,9 +186,6 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
     image_width, image_height : int
         Dimension of the Jupyter notebook's image widget, in pixels.
     """
-    # Allowed locations for cursor display
-    ALLOWED_CURSOR_LOCATIONS = ['top', 'bottom', None]
-
     # List of marker names that are for internal use only
     RESERVED_MARKER_SET_NAMES = ['all']
 
@@ -265,15 +263,13 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         self._updating_viewport = False
 
         # coordinates display
-        self._jup_coord = ipyw.HTML('Coordinates show up here')
         self._viewer.add_callback('cursor-changed', self._mouse_move_cb)
         self._viewer.add_callback('cursor-down', self._mouse_click_cb)
 
         # Output widget that captures printed output, for debugging.
         self._print_out = ipyw.Output()
 
-        self._cursor = 'bottom'
-        self.children = [self._jup_img, self._jup_coord]
+        self._init_cursor_info(self._jup_img)
 
     # ------------------------------------------------------------------
     # Read-only conveniences
@@ -324,30 +320,7 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
         data_x, data_y : float
             Cursor position, in data (pixel) coordinates.
         """
-        if self.cursor is None:  # no-op
-            return
-
-        image = viewer.get_image()
-        if image is not None:
-            ix = int(data_x + 0.5)
-            iy = int(data_y + 0.5)
-            try:
-                imval = viewer.get_data(ix, iy)
-                imval = '{:8.3f}'.format(imval)
-            except Exception:
-                imval = 'N/A'
-
-            val = 'X: {:.2f}, Y: {:.2f}'.format(data_x, data_y)
-            if image.wcs.wcs is not None:
-                try:
-                    ra, dec = image.pixtoradec(data_x, data_y)
-                    val += ' (RA: {}, DEC: {})'.format(
-                        ra_deg_to_str(ra), dec_deg_to_str(dec))
-                except Exception:
-                    val += ' (RA, DEC: WCS error)'
-
-            val += ', value: {}'.format(imval)
-            self._jup_coord.value = val
+        self._update_cursor_text(data_x, data_y)
 
     def _mouse_click_cb(self, viewer, event, data_x, data_y):
         """
@@ -735,31 +708,6 @@ class ImageWidget(ipyw.VBox, ImageViewerLogic):
             ``(X, Y)`` coordinates.
         """
         self.set_viewport(center=point)
-
-    @property
-    def cursor(self):
-        """
-        Show or hide cursor information (X, Y, WCS).
-        Acceptable values are 'top', 'bottom', or ``None``.
-        """
-        return self._cursor
-
-    @cursor.setter
-    def cursor(self, val):
-        if val is None:
-            self._jup_coord.layout.visibility = 'hidden'
-            self._jup_coord.layout.display = 'none'
-        elif val == 'top' or val == 'bottom':
-            self._jup_coord.layout.visibility = 'visible'
-            self._jup_coord.layout.display = 'flex'
-            if val == 'top':
-                self.layout.flex_flow = 'column-reverse'
-            else:
-                self.layout.flex_flow = 'column'
-        else:
-            raise ValueError('Invalid value {} for cursor. Valid values are: '
-                             '{}'.format(val, self.ALLOWED_CURSOR_LOCATIONS))
-        self._cursor = val
 
     @property
     def click_center(self):

--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -269,7 +269,7 @@ class ImageWidget(ipyw.VBox, CursorInfoMixin, ImageViewerLogic):
         # Output widget that captures printed output, for debugging.
         self._print_out = ipyw.Output()
 
-        self._init_cursor_info(self._jup_img)
+        self.children = [self._jup_img, self._init_cursor_info()]
 
     # ------------------------------------------------------------------
     # Read-only conveniences

--- a/astrowidgets/tests/conftest.py
+++ b/astrowidgets/tests/conftest.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from astropy.wcs import WCS
+
+
+@pytest.fixture
+def wcs():
+    # The Airy-projection example WCS from the astropy documentation, the
+    # same one used by the wcs fixture in
+    # astro_image_display_api.api_test.ImageAPITest.
+    w = WCS(naxis=2)
+    w.wcs.crpix = [-234.75, 8.3393]
+    w.wcs.cdelt = np.array([-0.066667, 0.066667])
+    w.wcs.crval = [0, -90]
+    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
+    w.wcs.set_pv([(2, 1, 45.0)])
+    return w

--- a/astrowidgets/tests/test_cursor_info.py
+++ b/astrowidgets/tests/test_cursor_info.py
@@ -2,28 +2,22 @@ import numpy as np
 import pytest
 
 from astropy import units as u
+from astropy.nddata import NDData
 from astropy.wcs import WCS
 
 from astrowidgets.cursor_info import format_cursor_text, READOUT_TEMPLATE
 
 
-def _make_wcs():
-    w = WCS(naxis=2)
-    w.wcs.crpix = [-234.75, 8.3393]
-    w.wcs.cdelt = np.array([-0.066667, 0.066667])
-    w.wcs.crval = [0, -90]
-    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
-    w.wcs.set_pv([(2, 1, 45.0)])
-    return w
+# The wcs fixture these tests use is shared across test modules; it lives
+# in conftest.py.
 
-
-def _make_data():
+@pytest.fixture
+def data():
     # Non-square so that a transposed x/y lookup is detectable.
     return np.arange(35, dtype=float).reshape(5, 7)
 
 
-def test_format_pixel_and_value():
-    data = _make_data()
+def test_format_pixel_and_value(data):
     text = format_cursor_text(3.0, 2.0, data=data)
     # data[y, x] = data[2, 3] = 17. Exact string: X/Y are width-5
     # left-aligned fields with a single space of separation, so a
@@ -31,22 +25,23 @@ def test_format_pixel_and_value():
     assert text == 'X: 3     Y: 2     value: 17.0'
 
 
-def test_format_uses_correct_pixel_to_world_order():
+def test_format_uses_correct_pixel_to_world_order(wcs, data):
     # Regression test: the bqplot backend used to call
     # wcs.pixel_to_world(y, x), transposing the sky coordinates.
-    wcs = _make_wcs()
     x, y = 3.0, 2.0
     good = wcs.pixel_to_world(x, y).icrs
     swapped = wcs.pixel_to_world(y, x).icrs
     assert good.ra.deg != swapped.ra.deg
 
-    text = format_cursor_text(x, y, data=_make_data(), wcs=wcs)
+    text = format_cursor_text(x, y, data=data, wcs=wcs)
     assert f'RA: {good.ra.deg:<8.4f}' in text
     assert f'Dec: {good.dec.deg:<+8.4f}' in text
 
 
-def test_format_sexagesimal():
-    wcs = _make_wcs()
+def test_format_sexagesimal(wcs):
+    # The sexagesimal readout must match astropy's own to_string
+    # rendering: RA as HH:MM:SS.ss (hours, zero-padded), Dec as
+    # +/-DD:MM:SS.ss (always signed).
     x, y = 3.0, 2.0
     sky = wcs.pixel_to_world(x, y).icrs
     text = format_cursor_text(x, y, wcs=wcs, sky_format='sexagesimal')
@@ -77,31 +72,31 @@ def test_format_galactic_wcs_converts_to_icrs_and_says_so():
 
 
 def test_format_invalid_sky_format():
+    # An unrecognized sky_format must raise rather than silently fall
+    # back to a default, and the error must name the bad argument.
     with pytest.raises(ValueError, match='sky_format'):
         format_cursor_text(1.0, 1.0, sky_format='hours')
 
 
 @pytest.mark.parametrize('x,y', [(7.0, 2.0), (3.0, 5.0), (-0.6, 2.0)])
-def test_format_out_of_bounds_value(x, y):
-    text = format_cursor_text(x, y, data=_make_data())
+def test_format_out_of_bounds_value(x, y, data):
+    text = format_cursor_text(x, y, data=data)
     assert 'value: N/A' in text
 
 
-def test_format_decimal_readout_is_fixed_width():
+def test_format_decimal_readout_is_fixed_width(wcs):
     # The X/Y and decimal RA/Dec fields are padded to a constant width
     # so the readout line does not jitter side-to-side as the cursor
     # moves, including across changes in digit count (9.99 -> 10.01).
-    wcs = _make_wcs()
-    data = np.zeros((200, 300))
-    lengths = {len(format_cursor_text(x, 2.0, data=data, wcs=wcs))
+    big_data = np.zeros((200, 300))
+    lengths = {len(format_cursor_text(x, 2.0, data=big_data, wcs=wcs))
                for x in (0.0, 9.99, 10.01, 100.0)}
     assert len(lengths) == 1
 
 
-def test_format_displayed_pixel_matches_sampled_pixel():
+def test_format_displayed_pixel_matches_sampled_pixel(data):
     # The X/Y readout shows the integer pixel the value is sampled from,
     # not the fractional cursor position.
-    data = _make_data()
     text = format_cursor_text(2.6, 1.4, data=data)
     assert f'X: {3:<5d}' in text
     assert f'Y: {1:<5d}' in text
@@ -109,11 +104,18 @@ def test_format_displayed_pixel_matches_sampled_pixel():
     assert 'value: 10.0' in text
 
 
-def test_format_negative_coordinate_does_not_alias_to_pixel_zero():
+def test_format_negative_coordinate_does_not_alias_to_pixel_zero(data):
     # int(x + 0.5) truncates toward zero, so a cursor at x=-0.4 would
     # wrongly read pixel 0; floor-based rounding must report N/A instead.
-    text = format_cursor_text(-0.6, 0.0, data=_make_data())
+    text = format_cursor_text(-0.6, 0.0, data=data)
     assert 'value: N/A' in text
+
+
+def test_format_accepts_list_data():
+    # data is documented as array-like, so a plain nested list must work,
+    # not just objects that already have .shape and 2D indexing.
+    text = format_cursor_text(1.0, 1.0, data=[[0.0, 1.0], [2.0, 3.0]])
+    assert 'value: 3.0' in text
 
 
 def test_format_no_data():
@@ -121,12 +123,12 @@ def test_format_no_data():
     assert 'value: N/A' in text
 
 
-def test_format_wcs_error():
+def test_format_wcs_error(data):
     class BrokenWCS:
         def pixel_to_world(self, x, y):
             raise ValueError('broken')
 
-    text = format_cursor_text(1.0, 1.0, data=_make_data(), wcs=BrokenWCS())
+    text = format_cursor_text(1.0, 1.0, data=data, wcs=BrokenWCS())
     assert 'RA/Dec: WCS error' in text
 
 
@@ -183,16 +185,14 @@ def test_sky_coordinate_format_property(backend):
 
 
 @pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
-def test_mouse_move_updates_readout(backend):
-    from astropy.nddata import NDData
-
+def test_mouse_move_updates_readout(backend, wcs):
     widget = _backend_widget(backend)
     data = np.arange(100.0 * 150).reshape(100, 150)
-    widget.load_image(NDData(data=data, wcs=_make_wcs()))
+    widget.load_image(NDData(data=data, wcs=wcs))
 
     _simulate_mouse_move(widget, backend, 3.0, 2.0)
     expected = READOUT_TEMPLATE.format(
-        format_cursor_text(3.0, 2.0, data=data, wcs=_make_wcs()))
+        format_cursor_text(3.0, 2.0, data=data, wcs=wcs))
     assert widget._cursor_readout.value == expected
 
 
@@ -204,19 +204,17 @@ def test_mouse_move_before_load_does_not_raise(backend):
 
 
 @pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
-def test_sky_format_change_updates_readout_immediately(backend):
+def test_sky_format_change_updates_readout_immediately(backend, wcs):
     # Regression test: changing sky_coordinate_format used to leave the
     # readout stale until the next mouse move.
-    from astropy.nddata import NDData
-
     widget = _backend_widget(backend)
     data = np.arange(100.0 * 150).reshape(100, 150)
-    widget.load_image(NDData(data=data, wcs=_make_wcs()))
+    widget.load_image(NDData(data=data, wcs=wcs))
 
     _simulate_mouse_move(widget, backend, 3.0, 2.0)
     widget.sky_coordinate_format = 'sexagesimal'
     expected = READOUT_TEMPLATE.format(
-        format_cursor_text(3.0, 2.0, data=data, wcs=_make_wcs(),
+        format_cursor_text(3.0, 2.0, data=data, wcs=wcs,
                            sky_format='sexagesimal'))
     assert widget._cursor_readout.value == expected
 
@@ -228,18 +226,17 @@ def test_sky_format_change_before_any_mouse_move(backend):
     assert widget._cursor_readout.value == 'Coordinates show up here'
 
 
-def test_backends_produce_identical_readout():
+def test_backends_produce_identical_readout(wcs):
     # The payoff of the shared module: both backends must produce the
     # same readout string for the same cursor position and image.
     pytest.importorskip('bqplot')
     pytest.importorskip('ginga')
-    from astropy.nddata import NDData
 
     data = np.arange(100.0 * 150).reshape(100, 150)
     readouts = []
     for backend in ('bqplot', 'ginga'):
         widget = _backend_widget(backend)
-        widget.load_image(NDData(data=data, wcs=_make_wcs()))
+        widget.load_image(NDData(data=data, wcs=wcs))
         _simulate_mouse_move(widget, backend, 12.25, 34.75)
         readouts.append(widget._cursor_readout.value)
 

--- a/astrowidgets/tests/test_cursor_info.py
+++ b/astrowidgets/tests/test_cursor_info.py
@@ -1,0 +1,258 @@
+import numpy as np
+import pytest
+
+from astropy import units as u
+from astropy.wcs import WCS
+
+from astrowidgets.cursor_info import format_cursor_text, READOUT_TEMPLATE
+
+
+def _make_wcs():
+    w = WCS(naxis=2)
+    w.wcs.crpix = [-234.75, 8.3393]
+    w.wcs.cdelt = np.array([-0.066667, 0.066667])
+    w.wcs.crval = [0, -90]
+    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
+    w.wcs.set_pv([(2, 1, 45.0)])
+    return w
+
+
+def _make_data():
+    # Non-square so that a transposed x/y lookup is detectable.
+    return np.arange(35, dtype=float).reshape(5, 7)
+
+
+def test_format_pixel_and_value():
+    data = _make_data()
+    text = format_cursor_text(3.0, 2.0, data=data)
+    # data[y, x] = data[2, 3] = 17. Exact string: X/Y are width-5
+    # left-aligned fields with a single space of separation, so a
+    # 5-digit pixel index is followed by exactly one space.
+    assert text == 'X: 3     Y: 2     value: 17.0'
+
+
+def test_format_uses_correct_pixel_to_world_order():
+    # Regression test: the bqplot backend used to call
+    # wcs.pixel_to_world(y, x), transposing the sky coordinates.
+    wcs = _make_wcs()
+    x, y = 3.0, 2.0
+    good = wcs.pixel_to_world(x, y).icrs
+    swapped = wcs.pixel_to_world(y, x).icrs
+    assert good.ra.deg != swapped.ra.deg
+
+    text = format_cursor_text(x, y, data=_make_data(), wcs=wcs)
+    assert f'RA: {good.ra.deg:<8.4f}' in text
+    assert f'Dec: {good.dec.deg:<+8.4f}' in text
+
+
+def test_format_sexagesimal():
+    wcs = _make_wcs()
+    x, y = 3.0, 2.0
+    sky = wcs.pixel_to_world(x, y).icrs
+    text = format_cursor_text(x, y, wcs=wcs, sky_format='sexagesimal')
+    ra = sky.ra.to_string(unit=u.hour, sep=':', precision=2, pad=True)
+    dec = sky.dec.to_string(unit=u.degree, sep=':', precision=2,
+                            alwayssign=True, pad=True)
+    assert f'RA: {ra}' in text
+    assert f'Dec: {dec}' in text
+
+
+def test_format_galactic_wcs_converts_to_icrs_and_says_so():
+    # The readout always shows ICRS, even for a galactic-native WCS
+    # (e.g. the Spitzer example image), and tags the segment to say so.
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50, 50]
+    wcs.wcs.cdelt = np.array([-0.001, 0.001])
+    wcs.wcs.crval = [18.35, 0.16]
+    wcs.wcs.ctype = ['GLON-CAR', 'GLAT-CAR']
+
+    x, y = 3.0, 2.0
+    sky = wcs.pixel_to_world(x, y)
+    assert sky.frame.name == 'galactic'
+    icrs = sky.icrs
+
+    text = format_cursor_text(x, y, wcs=wcs)
+    assert f'RA: {icrs.ra.deg:<8.4f}' in text
+    assert f'Dec: {icrs.dec.deg:<+8.4f} (ICRS)' in text
+
+
+def test_format_invalid_sky_format():
+    with pytest.raises(ValueError, match='sky_format'):
+        format_cursor_text(1.0, 1.0, sky_format='hours')
+
+
+@pytest.mark.parametrize('x,y', [(7.0, 2.0), (3.0, 5.0), (-0.6, 2.0)])
+def test_format_out_of_bounds_value(x, y):
+    text = format_cursor_text(x, y, data=_make_data())
+    assert 'value: N/A' in text
+
+
+def test_format_decimal_readout_is_fixed_width():
+    # The X/Y and decimal RA/Dec fields are padded to a constant width
+    # so the readout line does not jitter side-to-side as the cursor
+    # moves, including across changes in digit count (9.99 -> 10.01).
+    wcs = _make_wcs()
+    data = np.zeros((200, 300))
+    lengths = {len(format_cursor_text(x, 2.0, data=data, wcs=wcs))
+               for x in (0.0, 9.99, 10.01, 100.0)}
+    assert len(lengths) == 1
+
+
+def test_format_displayed_pixel_matches_sampled_pixel():
+    # The X/Y readout shows the integer pixel the value is sampled from,
+    # not the fractional cursor position.
+    data = _make_data()
+    text = format_cursor_text(2.6, 1.4, data=data)
+    assert f'X: {3:<5d}' in text
+    assert f'Y: {1:<5d}' in text
+    # data[y, x] = data[1, 3] = 10
+    assert 'value: 10.0' in text
+
+
+def test_format_negative_coordinate_does_not_alias_to_pixel_zero():
+    # int(x + 0.5) truncates toward zero, so a cursor at x=-0.4 would
+    # wrongly read pixel 0; floor-based rounding must report N/A instead.
+    text = format_cursor_text(-0.6, 0.0, data=_make_data())
+    assert 'value: N/A' in text
+
+
+def test_format_no_data():
+    text = format_cursor_text(1.0, 1.0)
+    assert 'value: N/A' in text
+
+
+def test_format_wcs_error():
+    class BrokenWCS:
+        def pixel_to_world(self, x, y):
+            raise ValueError('broken')
+
+    text = format_cursor_text(1.0, 1.0, data=_make_data(), wcs=BrokenWCS())
+    assert 'RA/Dec: WCS error' in text
+
+
+# ----------------------------------------------------------------------
+# Widget behavior, shared across backends
+# ----------------------------------------------------------------------
+
+def _backend_widget(backend):
+    if backend == 'bqplot':
+        pytest.importorskip('bqplot')
+        from astrowidgets.bqplot import ImageWidget
+    else:
+        pytest.importorskip('ginga')
+        from astrowidgets.ginga import ImageWidget
+    return ImageWidget()
+
+
+def _simulate_mouse_move(widget, backend, x, y):
+    if backend == 'bqplot':
+        # Simulate the comm message a real mouse move produces.
+        widget._astro_im.interaction._handle_custom_msg(
+            {'event': 'mousemove', 'domain': {'x': x, 'y': y}}, [])
+    else:
+        widget._mouse_move_cb(widget._viewer, None, x, y)
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_cursor_property(backend):
+    widget = _backend_widget(backend)
+    assert widget.cursor == 'bottom'
+    assert widget.layout.flex_flow == 'column'
+
+    widget.cursor = 'top'
+    assert widget.layout.flex_flow == 'column-reverse'
+    assert widget._cursor_readout.layout.visibility == 'visible'
+
+    widget.cursor = None
+    assert widget._cursor_readout.layout.display == 'none'
+
+    with pytest.raises(ValueError, match='cursor'):
+        widget.cursor = 'left'
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_sky_coordinate_format_property(backend):
+    widget = _backend_widget(backend)
+    assert widget.sky_coordinate_format == 'degrees'
+
+    widget.sky_coordinate_format = 'sexagesimal'
+    assert widget.sky_coordinate_format == 'sexagesimal'
+
+    with pytest.raises(ValueError, match='sky_coordinate_format'):
+        widget.sky_coordinate_format = 'radians'
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_mouse_move_updates_readout(backend):
+    from astropy.nddata import NDData
+
+    widget = _backend_widget(backend)
+    data = np.arange(100.0 * 150).reshape(100, 150)
+    widget.load_image(NDData(data=data, wcs=_make_wcs()))
+
+    _simulate_mouse_move(widget, backend, 3.0, 2.0)
+    expected = READOUT_TEMPLATE.format(
+        format_cursor_text(3.0, 2.0, data=data, wcs=_make_wcs()))
+    assert widget._cursor_readout.value == expected
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_mouse_move_before_load_does_not_raise(backend):
+    widget = _backend_widget(backend)
+    _simulate_mouse_move(widget, backend, 3.0, 2.0)
+    assert widget._cursor_readout.value == 'Coordinates show up here'
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_sky_format_change_updates_readout_immediately(backend):
+    # Regression test: changing sky_coordinate_format used to leave the
+    # readout stale until the next mouse move.
+    from astropy.nddata import NDData
+
+    widget = _backend_widget(backend)
+    data = np.arange(100.0 * 150).reshape(100, 150)
+    widget.load_image(NDData(data=data, wcs=_make_wcs()))
+
+    _simulate_mouse_move(widget, backend, 3.0, 2.0)
+    widget.sky_coordinate_format = 'sexagesimal'
+    expected = READOUT_TEMPLATE.format(
+        format_cursor_text(3.0, 2.0, data=data, wcs=_make_wcs(),
+                           sky_format='sexagesimal'))
+    assert widget._cursor_readout.value == expected
+
+
+@pytest.mark.parametrize('backend', ['bqplot', 'ginga'])
+def test_sky_format_change_before_any_mouse_move(backend):
+    widget = _backend_widget(backend)
+    widget.sky_coordinate_format = 'sexagesimal'
+    assert widget._cursor_readout.value == 'Coordinates show up here'
+
+
+def test_backends_produce_identical_readout():
+    # The payoff of the shared module: both backends must produce the
+    # same readout string for the same cursor position and image.
+    pytest.importorskip('bqplot')
+    pytest.importorskip('ginga')
+    from astropy.nddata import NDData
+
+    data = np.arange(100.0 * 150).reshape(100, 150)
+    readouts = []
+    for backend in ('bqplot', 'ginga'):
+        widget = _backend_widget(backend)
+        widget.load_image(NDData(data=data, wcs=_make_wcs()))
+        _simulate_mouse_move(widget, backend, 12.25, 34.75)
+        readouts.append(widget._cursor_readout.value)
+
+    assert readouts[0] == readouts[1]
+    # floor(12.25 + 0.5) = 12
+    assert f'X: {12:<5d}' in readouts[0]
+
+
+def test_bqplot_cursor_assignment_regression():
+    # Regression test: the AIDA slim-down (#215) removed the cursor
+    # property from the bqplot backend, silently breaking
+    # ``w.cursor = 'top'`` in the example notebook.
+    pytest.importorskip('bqplot')
+    widget = _backend_widget('bqplot')
+    widget.cursor = 'top'
+    assert widget.cursor == 'top'

--- a/astrowidgets/tests/test_widget_api_ginga.py
+++ b/astrowidgets/tests/test_widget_api_ginga.py
@@ -11,21 +11,10 @@ from astropy.visualization import (AsinhStretch, ContrastBiasStretch,
                                    LinearStretch, LogStretch, PowerDistStretch,
                                    PowerStretch, SinhStretch, SqrtStretch,
                                    SquaredStretch)
-from astropy.wcs import WCS
 from traitlets import TraitError
 
 from astro_image_display_api.api_test import ImageAPITest
 from astro_image_display_api import ImageViewerInterface
-
-
-def _make_wcs():
-    w = WCS(naxis=2)
-    w.wcs.crpix = [-234.75, 8.3393]
-    w.wcs.cdelt = np.array([-0.066667, 0.066667])
-    w.wcs.crval = [0, -90]
-    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
-    w.wcs.set_pv([(2, 1, 45.0)])
-    return w
 
 
 _ = pytest.importorskip("ginga",
@@ -204,9 +193,8 @@ def test_center_on_pixel_updates_viewport():
     assert center[1] == pytest.approx(40)
 
 
-def test_center_on_skycoord_updates_viewport():
+def test_center_on_skycoord_updates_viewport(wcs):
     # _center_on with a SkyCoord should re-center the stored viewport.
-    wcs = _make_wcs()
     image = ImageWidget()
     image.load_image(NDData(data=np.zeros((100, 150)), wcs=wcs))
     target = SkyCoord(*wcs.wcs.crval, unit='deg')

--- a/example_notebooks/bqplot_widget.ipynb
+++ b/example_notebooks/bqplot_widget.ipynb
@@ -712,13 +712,6 @@
     "print(\"Interactive marking is a bqplot-specific feature not in the API\")\n",
     "print(\"Use catalog-based marking instead with load_catalog()\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/example_notebooks/bqplot_widget.ipynb
+++ b/example_notebooks/bqplot_widget.ipynb
@@ -32,18 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ginga.misc.log import get_logger\n",
-    "\n",
-    "logger = get_logger('my viewer', log_stderr=True,\n",
-    "                    log_file=None, level=30)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "w = ImageWidget()"
    ]
   },
@@ -257,15 +245,6 @@
     "    new_dec = current_center.dec + deg_offset\n",
     "    new_center = SkyCoord(new_ra, new_dec, frame=current_center.frame)\n",
     "    w.set_viewport(center=new_center)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "current_center"
    ]
   },
   {
@@ -684,6 +663,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# The RA/Dec in the cursor info bar can be shown in decimal degrees\n",
+    "# (the default) or sexagesimal\n",
+    "w.sky_coordinate_format = 'sexagesimal'  # 'degrees', 'sexagesimal'\n",
+    "print(w.sky_coordinate_format)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Note: click_center is not part of the astro-image-display-api\n",
     "# This feature is bqplot-specific and not available through the API\n",
     "print(\"Click to center is a bqplot-specific feature not in the API\")"
@@ -721,6 +712,13 @@
     "print(\"Interactive marking is a bqplot-specific feature not in the API\")\n",
     "print(\"Use catalog-based marking instead with load_catalog()\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -739,7 +737,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The new `astrowidgets/cursor_info.py` holds a pure `format_cursor_text()` function and a `CursorInfoMixin` that owns the HTML readout widget, the `cursor` location property, and the data/WCS lookup through the AIDA logic layer, so the ginga and bqplot backends now produce identical readouts from a one-line forward of their native mouse-move events.

Along the way this fixes several readout bugs and rough edges:

- Restores the `cursor` property (`'top'`/`'bottom'`/`None`) on the bqplot backend, which was dropped in the AIDA slim-down (#215).
- Fixes the bqplot readout calling `pixel_to_world(y, x)` with swapped arguments, which displayed the sky position of the transposed pixel.
- Adds a `sky_coordinate_format` property selecting decimal degrees (the new default for both backends) or sexagesimal for the RA/Dec display; changing it re-renders the readout immediately at the last cursor position instead of waiting for the next mouse move.
- The sky position is always converted to ICRS whatever the native frame of the image WCS, and the readout is tagged `(ICRS)` to say so. (The pre-refactor ginga readout showed the native world coordinates — galactic l/b for the Spitzer example image — mislabelled as RA/Dec, with the longitude formatted in hours.)
- The X/Y and decimal RA/Dec fields are fixed width and the readout renders in a `<pre>` block, so the line no longer jitters side-to-side as the cursor moves.
- Uses floor-based rounding for the value lookup so cursor positions slightly outside the image no longer read pixel 0.

The shared behavior is covered by a new test module that runs the same assertions against both backends, including a test that both produce byte-identical readout strings for the same image and cursor position.

Fixes #203 

This PR was generated by Claude Code at Matt's direction.
Claude-Session: https://claude.ai/code/session_013M3uRgBJF5BwAVXhNhakTo