### PR TITLE
Support ginga master's normalized-float ColorDist hash contract

### DIFF
--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -36,6 +36,13 @@ from astrowidgets.cursor_info import CursorInfoMixin
 
 __all__ = ["ImageWidget"]
 
+# Released ginga (<= 7.0) expects a ColorDist ``hash`` holding integer levels
+# 0..colorlen-1; ginga master (unreleased 7.1) expects a normalized float 0..1
+# curve, scaled to the output level downstream by the Distribute stage.
+_GINGA_NORMALIZED_HASH = np.issubdtype(
+    ColorDist.LinearDist(16).hash.dtype, np.floating
+)
+
 
 class _AstropyStretchDist(ColorDist.ColorDistBase):
     """
@@ -72,15 +79,20 @@ class _AstropyStretchDist(ColorDist.ColorDistBase):
         Notes
         -----
         This method does not return a value; its side effect is to set
-        ``self.hash`` to the stretch evaluated on ginga's 0..1 ramp, scaled
-        to the color range.
+        ``self.hash`` to the stretch evaluated on ginga's 0..1 ramp, in the
+        representation the installed ginga expects (normalized float curve
+        on ginga master, integer levels scaled to the color range on
+        released ginga).
         """
         base = np.arange(0.0, float(self.hashsize), 1.0) / self.hashsize
         out = np.asarray(self.stretch(base, clip=True), dtype=float)
         out = np.clip(out, 0.0, 1.0)
-        # normalize to color range
-        ll = out * (self.colorlen - 1)
-        self.hash = ll.astype(np.uint, copy=False)
+        if _GINGA_NORMALIZED_HASH:
+            self.hash = out.astype(np.float32, copy=False)
+        else:
+            # normalize to color range
+            ll = out * (self.colorlen - 1)
+            self.hash = ll.astype(np.uint, copy=False)
         self.check_hash()
 
     def get_dist_pct(self, pct):

--- a/astrowidgets/tests/test_widget_api_ginga.py
+++ b/astrowidgets/tests/test_widget_api_ginga.py
@@ -35,21 +35,44 @@ def _loaded_widget():
     return image
 
 
-def _astropy_levels(stretch, dist):
-    # Reproduce the integer lookup table ginga would build from an astropy
-    # stretch evaluated on the same 0..1 ramp, so it can be compared against a
-    # configured ginga ColorDist's ``hash``.
+# Released ginga stores the ColorDist ``hash`` as integer levels
+# 0..colorlen-1; ginga master (unreleased 7.1) stores it as a normalized
+# float 0..1 curve and scales to the output level downstream.
+_GINGA_NORMALIZED_HASH = np.issubdtype(
+    ColorDist.LinearDist(16).hash.dtype, np.floating
+)
+
+
+def _expected_hash(stretch, dist):
+    # Reproduce the lookup table ginga would build from an astropy stretch
+    # evaluated on the same 0..1 ramp, in the same representation the
+    # installed ginga uses for a ColorDist's ``hash``.
     base = np.arange(0.0, float(dist.hashsize), 1.0) / dist.hashsize
     out = np.clip(np.asarray(stretch(base, clip=True), dtype=float), 0.0, 1.0)
+    if _GINGA_NORMALIZED_HASH:
+        return out.astype(np.float32)
     return (out * (dist.colorlen - 1)).astype(np.int64)
 
 
+def _assert_hash_matches(dist, stretch):
+    expected = _expected_hash(stretch, dist)
+    if _GINGA_NORMALIZED_HASH:
+        # The float32 storage of the same float64 computation; tolerance is
+        # far below one 8-bit quantization level (1/255).
+        np.testing.assert_allclose(dist.hash, expected, rtol=0.0, atol=1e-6)
+    else:
+        np.testing.assert_array_equal(dist.hash, expected)
+
+
 def _max_level_diff(dist, stretch):
-    return int(
-        np.abs(
-            dist.hash.astype(np.int64) - _astropy_levels(stretch, dist)
-        ).max()
-    )
+    # Largest difference between the configured dist and the astropy stretch,
+    # in units of 8-bit quantization levels whatever the hash representation.
+    diff = np.abs(
+        dist.hash.astype(np.float64) - _expected_hash(stretch, dist)
+    ).max()
+    if _GINGA_NORMALIZED_HASH:
+        diff *= 255
+    return round(diff)
 
 
 def test_instance():
@@ -106,7 +129,7 @@ def test_native_dist_matches_astropy_exactly(stretch):
     image = _loaded_widget()
     image.set_stretch(stretch)
     dist = image._viewer.get_rgbmap().get_dist()
-    np.testing.assert_array_equal(dist.hash, _astropy_levels(stretch, dist))
+    _assert_hash_matches(dist, stretch)
 
 
 @pytest.mark.parametrize(
@@ -149,7 +172,7 @@ def test_power_stretch_uses_adapter_not_ginga_power():
     image.set_stretch(stretch)
     dist = image._viewer.get_rgbmap().get_dist()
     assert not isinstance(dist, ColorDist.PowerDist)
-    np.testing.assert_array_equal(dist.hash, _astropy_levels(stretch, dist))
+    _assert_hash_matches(dist, stretch)
 
 
 def test_powerdist_stretch_maps_to_ginga_power():
@@ -169,7 +192,7 @@ def test_ginga_less_stretch_applied_faithfully_without_warning():
         warnings.simplefilter("error", AstropyUserWarning)
         image.set_stretch(stretch)
     dist = image._viewer.get_rgbmap().get_dist()
-    np.testing.assert_array_equal(dist.hash, _astropy_levels(stretch, dist))
+    _assert_hash_matches(dist, stretch)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The `devtests` job (`py313-test-devdeps`) is failing on every branch (e.g. [this run](https://github.com/astropy/astrowidgets/actions/runs/30206953028/job/89806586996)) with 7 failures in `test_widget_api_ginga.py`. The cause is upstream: ginga commit [`5c412ada9`](https://github.com/ejeschke/ginga/commit/5c412ada9) (unreleased, slated for 7.1.0) changed the `ColorDist` contract:

- **Released ginga (≤ 7.0.0):** `dist.hash` is an integer LUT with values `0..colorlen-1` (0–255).
- **Ginga master:** `dist.hash` is a normalized **float32 curve in 0.0–1.0**; scaling to the output bit depth moved downstream into the RGB-mapping `Distribute` stage, and `colorlen` is deprecated.

This had two effects here:

1. The stretch tests compared `dist.hash` against integer levels — a pure representation mismatch (the curves still agree).
2. A real bug on ginga master: `_AstropyStretchDist.calc_hash()` still baked integer levels into the hash. The new `Distribute` stage multiplies hash values by 255, so adapter-backed stretches (`PowerStretch`, `ContrastBiasStretch`, …) produced output levels up to **64260 instead of 0–255** — silently, because `check_hash()` no longer range-checks.

## What

Both the tests and the adapter now probe which contract the installed ginga uses (is `LinearDist(16).hash` a float array?) and act accordingly:

- **Tests** (first commit): expected hashes are built in the installed ginga's representation, with tolerances expressed in 8-bit quantization levels in both worlds. At this commit, the two adapter-backed tests correctly fail under ginga master, exposing bug 2.
- **Fix** (second commit): `_AstropyStretchDist.calc_hash()` stores the stretch curve as normalized float32 under the new contract, keeping the integer-level path for released ginga.

Fixes #225 

## Verification

Full suite passes (235 passed, 2 skipped) with both released ginga and ginga master at `7.1.0.dev16+g5e1ac35e0` (the exact commit from the failing CI run).

A heads-up issue about the silent breakage of third-party `ColorDist` subclasses has been filed upstream: ejeschke/ginga#1148.

https://claude.ai/code/session_01DhseEqKeQZQqc8uMniaj9K
