### PR TITLE
Activate setuptools_scm so builds get a real version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ MANIFEST
 .ipynb_checkpoints
 example_notebooks/test.png
 */version.py
+*/_version.py
 pip-wheel-metadata/
 
 # Sphinx

--- a/astrowidgets/__init__.py
+++ b/astrowidgets/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 try:
-    from .version import version as __version__
+    from ._version import version as __version__
 except ImportError:
     __version__ = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ build-backend = 'setuptools.build_meta'
 [tool.setuptools]
 packages = ["astrowidgets"]
 
+# setuptools_scm only activates when this section is present; without it the
+# dynamic version silently falls back to 0.0.0. version_file generates the
+# astrowidgets/version.py that __init__.py imports __version__ from.
+[tool.setuptools_scm]
+version_file = "astrowidgets/version.py"
+
 [tool.ruff]
 line-length = 79
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,9 @@ packages = ["astrowidgets"]
 
 # setuptools_scm only activates when this section is present; without it the
 # dynamic version silently falls back to 0.0.0. version_file generates the
-# astrowidgets/version.py that __init__.py imports __version__ from.
+# astrowidgets/_version.py that __init__.py imports __version__ from.
 [tool.setuptools_scm]
-version_file = "astrowidgets/version.py"
+version_file = "astrowidgets/_version.py"
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
The 0.6.0 release workflow ran successfully but published `astrowidgets-0.0.0` to PyPI ([release run log](https://github.com/astropy/astrowidgets/actions/runs/30213370845)); the real 0.6.0 never made it there.

**Root cause:** the project modernization removed `setup.py`/`setup.cfg`, leaving `setuptools_scm` listed in `build-system.requires` but never activated — setuptools_scm only turns on when a `[tool.setuptools_scm]` section (or `setup.py` opt-in) exists. With `dynamic = ["version"]` and no active version source, setuptools silently falls back to `0.0.0`. The same bug makes every git install report version 0.0.0, and since no `astrowidgets/version.py` is ever generated, `__init__.py`'s `from .version import version` fails and installed packages get `__version__ = ""`.

**Fix:** add the `[tool.setuptools_scm]` section, with `version_file = "astrowidgets/_version.py"` so the module `__init__.py` imports is generated again (`__init__.py` and `.gitignore` updated to match).

**Verified** by building from clean clones with `python -m build --wheel`:

- at tag `0.6.0` (before): `astrowidgets-0.0.0-py3-none-any.whl`
- on this branch (after): `astrowidgets-0.6.1.dev2+gdd8409788-py3-none-any.whl`, with the generated `_version.py` inside the wheel; the installed package reports `__version__ = '0.6.1.dev2+gdd8409788'`

**Not handled here** (release-side follow-ups after merge):

- ~~yank/delete the stray `0.0.0` release on PyPI~~ (done)
- re-tag `0.6.0` on the fixed commit (the PyPI `0.6.0` filename slot is unused, so republishing under the same version works) — or cut `0.6.1`

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcJuqpQTxx3Em7yCCmahXP
