### PR TITLE
Adopt ginga 7.1's public set_hash API in the stretch adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ New Features
 Bug Fixes
 ---------
 
+- Adapted the astropy-stretch color distribution used by the ginga
+  ``ImageWidget`` to the new ColorDist hash contract in the upcoming
+  ginga 7.1 (normalized float curve instead of integer levels), using
+  ginga's new public ``set_hash()`` API where available while remaining
+  compatible with released ginga. [#226, #229]
+
 - Fixed the RA/Dec shown in the bqplot ``ImageWidget`` cursor readout,
   which transposed the x and y pixel coordinates when converting to sky
   coordinates. Also fixed both backends reading pixel 0's value for

--- a/astrowidgets/ginga.py
+++ b/astrowidgets/ginga.py
@@ -37,11 +37,12 @@ from astrowidgets.cursor_info import CursorInfoMixin
 __all__ = ["ImageWidget"]
 
 # Released ginga (<= 7.0) expects a ColorDist ``hash`` holding integer levels
-# 0..colorlen-1; ginga master (unreleased 7.1) expects a normalized float 0..1
-# curve, scaled to the output level downstream by the Distribute stage.
-_GINGA_NORMALIZED_HASH = np.issubdtype(
-    ColorDist.LinearDist(16).hash.dtype, np.floating
-)
+# 0..colorlen-1. ginga 7.1 expects a normalized float 0..1 curve, scaled to
+# the output level downstream by the Distribute stage and installed via the
+# public ``set_hash()`` helper added in the fix for
+# https://github.com/ejeschke/ginga/issues/1148.
+# TODO: drop the legacy branch when astrowidgets requires ginga >= 7.1.
+_GINGA_HAS_SET_HASH = hasattr(ColorDist.ColorDistBase, "set_hash")
 
 
 class _AstropyStretchDist(ColorDist.ColorDistBase):
@@ -81,19 +82,19 @@ class _AstropyStretchDist(ColorDist.ColorDistBase):
         This method does not return a value; its side effect is to set
         ``self.hash`` to the stretch evaluated on ginga's 0..1 ramp, in the
         representation the installed ginga expects (normalized float curve
-        on ginga master, integer levels scaled to the color range on
-        released ginga).
+        stored through ``set_hash()`` on ginga >= 7.1, integer levels scaled
+        to the color range on released ginga).
         """
         base = np.arange(0.0, float(self.hashsize), 1.0) / self.hashsize
         out = np.asarray(self.stretch(base, clip=True), dtype=float)
         out = np.clip(out, 0.0, 1.0)
-        if _GINGA_NORMALIZED_HASH:
-            self.hash = out.astype(np.float32, copy=False)
+        if _GINGA_HAS_SET_HASH:
+            self.set_hash(out)
         else:
             # normalize to color range
             ll = out * (self.colorlen - 1)
             self.hash = ll.astype(np.uint, copy=False)
-        self.check_hash()
+            self.check_hash()
 
     def get_dist_pct(self, pct):
         """

--- a/astrowidgets/tests/test_widget_api_ginga.py
+++ b/astrowidgets/tests/test_widget_api_ginga.py
@@ -35,12 +35,11 @@ def _loaded_widget():
     return image
 
 
-# Released ginga stores the ColorDist ``hash`` as integer levels
-# 0..colorlen-1; ginga master (unreleased 7.1) stores it as a normalized
-# float 0..1 curve and scales to the output level downstream.
-_GINGA_NORMALIZED_HASH = np.issubdtype(
-    ColorDist.LinearDist(16).hash.dtype, np.floating
-)
+# Released ginga (<= 7.0) stores the ColorDist ``hash`` as integer levels
+# 0..colorlen-1; ginga 7.1 stores it as a normalized float 0..1 curve
+# installed via the public ``set_hash()`` helper added in the fix for
+# https://github.com/ejeschke/ginga/issues/1148.
+_GINGA_HAS_SET_HASH = hasattr(ColorDist.ColorDistBase, "set_hash")
 
 
 def _expected_hash(stretch, dist):
@@ -49,14 +48,14 @@ def _expected_hash(stretch, dist):
     # installed ginga uses for a ColorDist's ``hash``.
     base = np.arange(0.0, float(dist.hashsize), 1.0) / dist.hashsize
     out = np.clip(np.asarray(stretch(base, clip=True), dtype=float), 0.0, 1.0)
-    if _GINGA_NORMALIZED_HASH:
+    if _GINGA_HAS_SET_HASH:
         return out.astype(np.float32)
     return (out * (dist.colorlen - 1)).astype(np.int64)
 
 
 def _assert_hash_matches(dist, stretch):
     expected = _expected_hash(stretch, dist)
-    if _GINGA_NORMALIZED_HASH:
+    if _GINGA_HAS_SET_HASH:
         # The float32 storage of the same float64 computation; tolerance is
         # far below one 8-bit quantization level (1/255).
         np.testing.assert_allclose(dist.hash, expected, rtol=0.0, atol=1e-6)
@@ -70,7 +69,7 @@ def _max_level_diff(dist, stretch):
     diff = np.abs(
         dist.hash.astype(np.float64) - _expected_hash(stretch, dist)
     ).max()
-    if _GINGA_NORMALIZED_HASH:
+    if _GINGA_HAS_SET_HASH:
         diff *= 255
     return round(diff)
 
@@ -173,6 +172,17 @@ def test_power_stretch_uses_adapter_not_ginga_power():
     dist = image._viewer.get_rgbmap().get_dist()
     assert not isinstance(dist, ColorDist.PowerDist)
     _assert_hash_matches(dist, stretch)
+
+
+def test_adapter_emits_no_deprecation_warning():
+    # On ginga >= 7.1 a PendingDeprecationWarning from check_hash() means the
+    # adapter stored an old-contract integer hash and was rescued by ginga's
+    # backward-compat shim (ejeschke/ginga#1148); the adapter must store the
+    # representation the installed ginga expects, on every ginga version.
+    image = _loaded_widget()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        image.set_stretch(PowerStretch(3.0))
 
 
 def test_powerdist_stretch_maps_to_ginga_power():


### PR DESCRIPTION
## Summary

Follow-up to #226. The upstream issue we reported, ejeschke/ginga#1148, was fixed on ginga master (7.1.0.dev17): ginga now provides a public `set_hash(base)` helper as the supported way for `ColorDist` subclasses to install their normalized 0..1 curve, plus a build-time backward-compat shim in `check_hash()` that rescues old-contract integer hashes with a `PendingDeprecationWarning`.

This PR updates our compatibility code to track that resolution:

- `_AstropyStretchDist.calc_hash` now installs the curve through the public `set_hash()` on ginga >= 7.1 instead of assigning `self.hash` directly; the integer-levels branch is kept for released ginga (<= 7.0), with a TODO to drop it once we require ginga >= 7.1.
- The contract probe (here and in the tests) is now `hasattr(ColorDist.ColorDistBase, "set_hash")` rather than sniffing the hash dtype of a throwaway `LinearDist`.
- New regression test asserting the adapter never triggers ginga's deprecation shim.
- Adds the changelog entry that #226 was missing, folded with this change.

We cannot remove the dual-contract code yet: released ginga still requires the integer-levels representation and has no `set_hash`, and `pyproject.toml` allows `ginga>=3.4`.

## Testing

- `pixi run test` against ginga 7.0.0: 236 passed, 2 skipped (legacy branch).
- Venv with ginga master 7.1.0.dev17 (includes the #1148 fix): all 111 ginga tests pass with `-W error::PendingDeprecationWarning`, confirming `set_hash()` is used and the compat shim never fires.

Co-written with Claude Fable 5

https://claude.ai/code/session_019GuBhnNvskTtCsb6Pw69BC