### PR TITLE
Reduce redundant CI matrix jobs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -17,11 +17,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -62,16 +58,11 @@ jobs:
         run-install: false
     - name: Set up pixi environment
       run: pixi install
-    - name: Verify install
-      run: pixi run python -c "import astrowidgets"
     - name: Run tests (pixi)
       run: pixi run test
 
   pixi-downstream:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -86,17 +77,9 @@ jobs:
     - name: Add dependencies (simulate user env)
       working-directory: downstream
       run: pixi add numpy scipy astropy ipywidgets
-    - name: Add local package (Unix)
-      if: runner.os != 'Windows'
+    - name: Add local package
       working-directory: downstream
       run: pixi add --pypi "astrowidgets @ file://$GITHUB_WORKSPACE"
-    - name: Add local package (Windows)
-      if: runner.os == 'Windows'
-      working-directory: downstream
-      shell: pwsh
-      run: |
-        $path = $env:GITHUB_WORKSPACE -replace '\\','/'
-        pixi add --pypi ("astrowidgets @ file:///" + $path)
     - name: Install and verify
       working-directory: downstream
       run: |


### PR DESCRIPTION
## Summary

- keep the tox packaging and documentation test path on Ubuntu
- retain the three-platform pixi matrix for OS coverage
- run the downstream pixi install smoke test on Ubuntu and remove its now-unneeded platform branch
- remove the redundant import check from the pixi job, since the test step imports the package

This reduces the workflow from 10 runner jobs to 6 while preserving each distinct test path.

## Validation

- `actionlint 1.7.12 .github/workflows/ci_workflows.yml`
- parsed the workflow and checked the expected runner/matrix structure with PyYAML

Closes #227
